### PR TITLE
fix(#53): Panel now syncs with variable value from URL query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#30](https://github.com/matheus-meneses/grafana-dynamic-search/issues/30): Fixed variable not being cleared when selection is removed
 - [#52](https://github.com/matheus-meneses/grafana-dynamic-search/issues/52): Fixed backspace clearing not updating dashboard variable
+- [#53](https://github.com/matheus-meneses/grafana-dynamic-search/issues/53): Panel now syncs with variable value from URL query parameters on load
 
 ### Changed
 

--- a/src/components/DynamicSearchPanel.spec.tsx
+++ b/src/components/DynamicSearchPanel.spec.tsx
@@ -24,6 +24,7 @@ const mockLocationService = {
   partial: jest.fn(),
 };
 const mockGetVariables = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -35,6 +36,7 @@ jest.mock('@grafana/runtime', () => ({
   },
   getTemplateSrv: () => ({
     getVariables: () => mockGetVariables(),
+    replace: (input: string) => mockReplace(input),
   }),
 }));
 
@@ -122,6 +124,7 @@ describe('DynamicSearchPanel', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockGetVariables.mockReturnValue([{ name: 'testVar', type: 'query' }]);
+        mockReplace.mockImplementation((input: string) => input);
     });
 
     it('renders config warning when datasource is missing', async () => {
@@ -952,5 +955,116 @@ describe('DynamicSearchPanel - Input Clearing Behavior', () => {
 
         fireEvent.click(screen.getByTestId('option-value-b'));
         expect(mockLocationService.partial).toHaveBeenCalledWith({ 'var-testVar': 'value-b' }, true);
+    });
+});
+
+describe('DynamicSearchPanel - URL Variable Sync', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetVariables.mockReturnValue([{ name: 'testVar', type: 'query' }]);
+    });
+
+    it('should pre-populate selected value from URL variable on mount', async () => {
+        mockReplace.mockImplementation((input: string) => {
+            if (input === '$testVar') {
+                return '/api/users';
+            }
+            return input;
+        });
+
+        render(<DynamicSearchPanel {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toBeInTheDocument();
+        });
+        expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toHaveTextContent('/api/users');
+    });
+
+    it('should not pre-populate when variable has no value', async () => {
+        mockReplace.mockImplementation((input: string) => input);
+
+        render(<DynamicSearchPanel {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dynamic-search-panel-wrapper')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('dynamic-search-panel-selected-badge')).not.toBeInTheDocument();
+    });
+
+    it('should not pre-populate when variable name is not configured', async () => {
+        mockReplace.mockImplementation((input: string) => 'some-value');
+
+        render(<DynamicSearchPanel {...defaultProps} options={{ ...defaultOptions, variableName: undefined }} />);
+
+        expect(screen.queryByTestId('dynamic-search-panel-selected-badge')).not.toBeInTheDocument();
+    });
+
+    it('should allow clearing pre-populated value via clear button', async () => {
+        mockReplace.mockImplementation((input: string) => {
+            if (input === '$testVar') {
+                return 'pre-filled-value';
+            }
+            return input;
+        });
+
+        render(<DynamicSearchPanel {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toBeInTheDocument();
+        });
+        expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toHaveTextContent('pre-filled-value');
+
+        fireEvent.click(screen.getByTestId('combobox-clear'));
+
+        expect(mockLocationService.partial).toHaveBeenCalledWith({ 'var-testVar': '' }, true);
+        await waitFor(() => {
+            expect(screen.queryByTestId('dynamic-search-panel-selected-badge')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should allow selecting new value after clearing pre-populated value', async () => {
+        mockReplace.mockImplementation((input: string) => {
+            if (input === '$testVar') {
+                return 'initial-value';
+            }
+            return input;
+        });
+
+        const mockMetricFindQuery = jest.fn().mockResolvedValue([
+            { text: 'new-selection', value: 'new-selection' }
+        ]);
+        mockGetDataSourceSrv.mockReturnValue({
+            metricFindQuery: mockMetricFindQuery,
+        });
+
+        render(<DynamicSearchPanel {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toHaveTextContent('initial-value');
+        });
+
+        fireEvent.click(screen.getByTestId('combobox-clear'));
+        mockLocationService.partial.mockClear();
+
+        const input = screen.getByTestId('combobox-input');
+        fireEvent.change(input, { target: { value: 'new' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('option-new-selection')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('option-new-selection'));
+
+        expect(mockLocationService.partial).toHaveBeenCalledWith({ 'var-testVar': 'new-selection' }, true);
+    });
+
+    it('should handle getTemplateSrv.replace throwing error gracefully', async () => {
+        mockReplace.mockImplementation(() => {
+            throw new Error('Template service error');
+        });
+
+        expect(() => render(<DynamicSearchPanel {...defaultProps} />)).not.toThrow();
+        expect(screen.getByTestId('dynamic-search-panel-wrapper')).toBeInTheDocument();
+        expect(screen.queryByTestId('dynamic-search-panel-selected-badge')).not.toBeInTheDocument();
     });
 });

--- a/src/components/DynamicSearchPanel.tsx
+++ b/src/components/DynamicSearchPanel.tsx
@@ -155,18 +155,36 @@ interface ConfigStatus {
   warnings: string[];
 }
 
+const getInitialVariableValue = (variableName: string | undefined): SelectableValue<string> | null => {
+  if (!variableName) {
+    return null;
+  }
+  try {
+    const templateSrv = getTemplateSrv();
+    const currentValue = templateSrv.replace(`$${variableName}`);
+    if (currentValue && currentValue !== `$${variableName}`) {
+      return { label: currentValue, value: currentValue };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
 const DynamicSearchPanelComponent: React.FC<Props> = ({ options, width, height }) => {
   const styles = useStyles2(getStyles);
-  const [selectedValue, setSelectedValue] = useState<SelectableValue<string> | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [hasSearched, setHasSearched] = useState(false);
-  const [lastResultCount, setLastResultCount] = useState<number | null>(null);
-
   const { datasourceUid, queryType, label, metric, variableName, regex } = options;
   const minChars = options.minChars ?? MIN_SEARCH_LENGTH;
   const maxResults = options.maxResults ?? 0;
   const placeholder = options.placeholder ?? 'Type to search...';
   const searchMode = options.searchMode ?? SEARCH_MODE.CONTAINS;
+
+  const [selectedValue, setSelectedValue] = useState<SelectableValue<string> | null>(() =>
+    getInitialVariableValue(variableName)
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [lastResultCount, setLastResultCount] = useState<number | null>(null);
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);


### PR DESCRIPTION
## Description

Fixed the panel to read and display the current variable value from URL query parameters on load.

### Changes:
- Added `getInitialVariableValue` helper function to read variable value from `getTemplateSrv().replace()`
- Initialize `selectedValue` state using a lazy initializer that reads the current URL variable value
- Panel now displays the correct selected badge when loading a dashboard with pre-filled URL parameters (e.g., `?var-path=/api/users`)

## Related Issue

Fixes #53

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the project's code style
- [x] I have run `npm run lint` with no errors
- [x] I have run `npm run test:ci` with no failures
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A - behavior fix