### PR TITLE
chore(deps): bump @grafana/* to 13.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
-        "@grafana/data": "^12.4.2",
-        "@grafana/i18n": "^12.4.2",
-        "@grafana/runtime": "^12.4.2",
-        "@grafana/schema": "^12.3.1",
-        "@grafana/ui": "^12.3.1",
+        "@grafana/data": "^13.0.1",
+        "@grafana/i18n": "^13.0.1",
+        "@grafana/runtime": "^13.0.1",
+        "@grafana/schema": "^13.0.1",
+        "@grafana/ui": "^13.0.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
@@ -81,21 +81,21 @@
       "license": "MIT"
     },
     "node_modules/@adobe/react-spectrum": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.47.0.tgz",
-      "integrity": "sha512-EDQuMzz0kUeiMUUlxoeLFQyyxOXaAC7qlBw2PYOUfFLYd87xcV7VVV0JxiYx8zGk1IIY3UgQHgXrS1fv7CgezQ==",
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.47.1.tgz",
+      "integrity": "sha512-mijNyd8XmA6KoBMbqKc4Rp+S2voKdZkPydJFjQbG0SkOjOKcgqVpJdKGsKdLMZBn9Jk5SgEuklyrhc7Uvot2tA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.1",
-        "@react-types/shared": "^3.34.0",
-        "@spectrum-icons/ui": "^3.7.0",
-        "@spectrum-icons/workflow": "^4.3.0",
+        "@internationalized/date": "^3.12.2",
+        "@react-types/shared": "^3.35.0",
+        "@spectrum-icons/ui": "^3.7.1",
+        "@spectrum-icons/workflow": "^4.3.1",
         "@swc/helpers": "^0.5.0",
         "client-only": "^0.0.1",
         "clsx": "^2.0.0",
-        "react-aria": "3.48.0",
-        "react-aria-components": "1.17.0",
-        "react-stately": "3.46.0",
+        "react-aria": "3.49.0",
+        "react-aria-components": "1.18.0",
+        "react-stately": "3.47.0",
         "react-transition-group": "^4.4.5",
         "use-sync-external-store": "^1.6.0"
       },
@@ -1229,13 +1229,13 @@
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.16",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
-      "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.6",
-        "@floating-ui/utils": "^0.2.10",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
@@ -1325,14 +1325,14 @@
       }
     },
     "node_modules/@grafana/data": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.4.2.tgz",
-      "integrity": "sha512-VjvxJFYnENiuYlSDSzfh5AqB5foET+MUq4HQMZQmCa3Svm+anECzsN0rRF8Yn/uA8Lx+9z5d77hESgEUpyBKcQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-13.0.2.tgz",
+      "integrity": "sha512-JCqxmNQKD3qkwHQtk1HQFxonfbLsRPf63MpxUtnzHhmUTJ/hfoKYWgpkLrSkbUpFrCPooV2zTpa8oak99rVAiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@braintree/sanitize-url": "7.0.1",
-        "@grafana/i18n": "12.4.2",
-        "@grafana/schema": "12.4.2",
+        "@grafana/i18n": "13.0.2",
+        "@grafana/schema": "13.0.2",
         "@leeoniya/ufuzzy": "1.0.19",
         "@types/d3-interpolate": "^3.0.0",
         "@types/string-hash": "1.1.3",
@@ -1340,7 +1340,7 @@
         "d3-interpolate": "3.0.1",
         "d3-scale-chromatic": "3.1.0",
         "date-fns": "4.1.0",
-        "dompurify": "3.3.0",
+        "dompurify": "3.3.2",
         "eventemitter3": "5.0.1",
         "fast_array_intersect": "1.1.0",
         "history": "4.10.1",
@@ -1363,65 +1363,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/data/node_modules/@grafana/i18n": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.2.tgz",
-      "integrity": "sha512-PcT0oI0xE7bl/nLqnLKawQGDC6TT/uADmegHRf+JP/mE7VeJKwloj3MWVzi5T4r7JE5s2VlG7nQiEWn5qdHhUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@formatjs/intl-durationformat": "^0.7.0",
-        "@typescript-eslint/utils": "^8.33.1",
-        "fast-deep-equal": "^3.1.3",
-        "i18next": "^25.0.0",
-        "i18next-browser-languagedetector": "^8.0.0",
-        "i18next-pseudo": "^2.2.1",
-        "micro-memoize": "^4.1.2",
-        "react-i18next": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@grafana/data/node_modules/react-i18next": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
-      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "html-parse-stringify": "^3.0.1"
-      },
-      "peerDependencies": {
-        "i18next": ">= 23.4.0",
-        "react": ">= 16.8.0",
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@grafana/data/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@grafana/e2e-selectors": {
@@ -1469,30 +1410,30 @@
       }
     },
     "node_modules/@grafana/faro-core": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.19.0.tgz",
-      "integrity": "sha512-Juo5G/aviSh3XqSGGr6D61noAC8sb+oCawBsv545ILEeOQdINyzRaoQdRpnXEY3DLS9LYtL0PYhvHZiP3rlscQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.7.1.tgz",
+      "integrity": "sha512-qJOp0sPBAEsmUxhs11nVdGx5Dk+VJ4CN/4s9ek99m33FfzybmjQ9nPXLHWhwEeNJNiEwQdDl4HsNUlXBGT5YEw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/otlp-transformer": "^0.202.0"
+        "@opentelemetry/otlp-transformer": "^0.218.0"
       }
     },
     "node_modules/@grafana/faro-web-sdk": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.19.0.tgz",
-      "integrity": "sha512-3u74mV2uBWqoF6WBx71p0vtkaS1Z0QbGoZ8tuX5yiYnIybqnhKdGkApFUi7q5se0tMPIeJdMVoRFdLU8f9hfAw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.7.1.tgz",
+      "integrity": "sha512-ZK3MuE6FWBmiT5tTivcMovTVe8fG1tPm1ctc84blVoJkpQXlgODxOX7/fNmDBOjaHZ3EWdoGplZmjoXQ3g0mDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/faro-core": "^1.19.0",
-        "ua-parser-js": "^1.0.32",
-        "web-vitals": "^4.0.1"
+        "@grafana/faro-core": "^2.7.1",
+        "ua-parser-js": "1.0.41",
+        "web-vitals": "^5.1.0"
       }
     },
     "node_modules/@grafana/i18n": {
-      "version": "12.4.3",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.3.tgz",
-      "integrity": "sha512-ECdz96IEk04rOZLMZSXTa6+6z+fgaIk9oHoyZC68Wzq1pkfQajdi7bnDCZ3Zsz5ikq1gEqIJpLgdL69Nd9lmdg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-13.0.2.tgz",
+      "integrity": "sha512-hNH3kkwR8ST1BNMD8XJJQQ0tP/o5x+ALW22NIa+GKGX0a/C+rZz3de+BOTQwyzukRX4CQiXkC3Yq9nKiQjj8WQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@formatjs/intl-durationformat": "^0.7.0",
@@ -1534,20 +1475,6 @@
         }
       }
     },
-    "node_modules/@grafana/i18n/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@grafana/plugin-e2e": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.7.0.tgz",
@@ -1573,20 +1500,34 @@
         }
       }
     },
+    "node_modules/@grafana/react-data-grid": {
+      "version": "7.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@grafana/react-data-grid/-/react-data-grid-7.0.0-beta.57.tgz",
+      "integrity": "sha512-v3DuW+TF16Jq5/dNJc0ifReBuknZb4+deB7M+liLMUU8sr2RavguNHpxCk4L/AdqLeXJFGhhqEDUYpeeQm2DzA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0",
+        "react-dom": "^18.0 || ^19.0"
+      }
+    },
     "node_modules/@grafana/runtime": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-12.4.2.tgz",
-      "integrity": "sha512-EKXEBwQ+sCQUyxt4phYRICCQCzRNPLcM5WvkiKMfpm9DQxgHLUQ9hX8HPptdN/BTzlWolOcQnwMYmcbWTMmCoA==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-13.0.2.tgz",
+      "integrity": "sha512-XIKO7/tgRW2PfV/PQwKEnmHFOKVUDobpydh2WIDEtknSAbZYEF+qlHQcbi8RHmPDOXpfK3cj/HTghjYqVRuevw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/data": "12.4.2",
-        "@grafana/e2e-selectors": "12.4.2",
-        "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/schema": "12.4.2",
-        "@grafana/ui": "12.4.2",
-        "@openfeature/core": "^1.9.0",
-        "@openfeature/ofrep-web-provider": "^0.3.3",
-        "@openfeature/react-sdk": "^1.2.0",
+        "@grafana/data": "13.0.2",
+        "@grafana/e2e-selectors": "13.0.2",
+        "@grafana/faro-web-sdk": "^2.2.4",
+        "@grafana/schema": "13.0.2",
+        "@grafana/ui": "13.0.2",
+        "@openfeature/core": "^1.9.2",
+        "@openfeature/ofrep-web-provider": "^0.3.6",
+        "@openfeature/react-sdk": "^1.2.1",
+        "@openfeature/web-sdk": "^1.7.3",
         "@types/systemjs": "6.15.3",
         "history": "4.10.1",
         "lodash": "^4.17.23",
@@ -1601,9 +1542,9 @@
       }
     },
     "node_modules/@grafana/runtime/node_modules/@grafana/e2e-selectors": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.2.tgz",
-      "integrity": "sha512-Kx2joGz/jql32HgD6+pJTHRkAGL7rJC+WE+fl/wZFThmQUIGpuJjwJYL0aOmYvOZeWwVLFnyrFCiNs48s3AZJg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.0.2.tgz",
+      "integrity": "sha512-XQvEVuz9PxW4oG/yJns7EjFS2cVU2UcbwTX1XqYJs4X7KCtpMvs9VpjqOa6wNuUnbhgKqgEOEGXiW2FnPNNBwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.0",
@@ -1625,9 +1566,9 @@
       }
     },
     "node_modules/@grafana/schema": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.4.2.tgz",
-      "integrity": "sha512-dkIEvcqTMitGO1qQcg4Hd2RoLK/YcQCNZQusX4sINvWH64u3uryBn3TS6TTPItvkiccWULYuZSWcQMV478i9Yg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-13.0.2.tgz",
+      "integrity": "sha512-EQUi+UDicmhGWncgw5mXWF9z1dgko3YrCu1WJHq4qTtkaLrVI/Zh8pz2gRlAXUrmFeICAc/FVPF1YI81EKLMZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1641,20 +1582,21 @@
       "license": "Apache-2.0"
     },
     "node_modules/@grafana/ui": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.4.2.tgz",
-      "integrity": "sha512-IGXmL0nW2PbdXIpXhyUuPDgG6GEcTITKwDfR96HYhEF9bbYQ8gAmhy1rSKZnkw/wg7Jk97o8ukGLvrZ3w2VavQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-13.0.2.tgz",
+      "integrity": "sha512-6tBOKsR35j4AmSRY4tPLtR66bBsodQBQK4wuzbRbcLl7RR6VX/IuUg3EOGw/xoOh7rSuOpMLKyjZ8dU4QO7J0w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
         "@emotion/react": "11.14.0",
         "@emotion/serialize": "1.3.3",
-        "@floating-ui/react": "0.27.16",
-        "@grafana/data": "12.4.2",
-        "@grafana/e2e-selectors": "12.4.2",
-        "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/i18n": "12.4.2",
-        "@grafana/schema": "12.4.2",
+        "@floating-ui/react": "0.27.19",
+        "@grafana/data": "13.0.2",
+        "@grafana/e2e-selectors": "13.0.2",
+        "@grafana/faro-web-sdk": "^2.2.4",
+        "@grafana/i18n": "13.0.2",
+        "@grafana/react-data-grid": "7.0.0-beta.57",
+        "@grafana/schema": "13.0.2",
         "@hello-pangea/dnd": "18.0.1",
         "@monaco-editor/react": "4.7.0",
         "@popperjs/core": "2.11.8",
@@ -1680,7 +1622,7 @@
         "hoist-non-react-statics": "3.3.2",
         "i18next": "^25.0.0",
         "i18next-browser-languagedetector": "^8.0.0",
-        "immutable": "5.1.4",
+        "immutable": "^5.1.5",
         "is-hotkey": "0.2.0",
         "jquery": "3.7.1",
         "lodash": "^4.17.23",
@@ -1692,7 +1634,6 @@
         "react-calendar": "^6.0.0",
         "react-colorful": "5.6.1",
         "react-custom-scrollbars-2": "4.5.0",
-        "react-data-grid": "github:grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed",
         "react-dropzone": "14.3.8",
         "react-highlight-words": "0.21.0",
         "react-hook-form": "^7.49.2",
@@ -1722,9 +1663,9 @@
       }
     },
     "node_modules/@grafana/ui/node_modules/@grafana/e2e-selectors": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.2.tgz",
-      "integrity": "sha512-Kx2joGz/jql32HgD6+pJTHRkAGL7rJC+WE+fl/wZFThmQUIGpuJjwJYL0aOmYvOZeWwVLFnyrFCiNs48s3AZJg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.0.2.tgz",
+      "integrity": "sha512-XQvEVuz9PxW4oG/yJns7EjFS2cVU2UcbwTX1XqYJs4X7KCtpMvs9VpjqOa6wNuUnbhgKqgEOEGXiW2FnPNNBwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.0",
@@ -1743,25 +1684,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@grafana/ui/node_modules/@grafana/i18n": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.2.tgz",
-      "integrity": "sha512-PcT0oI0xE7bl/nLqnLKawQGDC6TT/uADmegHRf+JP/mE7VeJKwloj3MWVzi5T4r7JE5s2VlG7nQiEWn5qdHhUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@formatjs/intl-durationformat": "^0.7.0",
-        "@typescript-eslint/utils": "^8.33.1",
-        "fast-deep-equal": "^3.1.3",
-        "i18next": "^25.0.0",
-        "i18next-browser-languagedetector": "^8.0.0",
-        "i18next-pseudo": "^2.2.1",
-        "micro-memoize": "^4.1.2",
-        "react-i18next": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
       }
     },
     "node_modules/@grafana/ui/node_modules/react-i18next": {
@@ -1788,20 +1710,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@grafana/ui/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@grafana/ui/node_modules/uuid": {
@@ -1896,18 +1804,18 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
-      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/message": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.9.tgz",
-      "integrity": "sha512-x03MSVTaB/4JHtW1VAYaY/2cCuBrHbWM6ZvlgpKdnSdW28tZbqpR673RJrVJyXWRw1bpgYN89Tz7ohX5tgNgPA==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.10.tgz",
+      "integrity": "sha512-nc0Or6EdWHqZRcsXb6P9hBIpLsfSl/ILh0rk5h/OVBpzmhdExXtPy2cQtWsq8XKRBpRHwDNnAHt4OpolcB7dog==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1915,18 +1823,18 @@
       }
     },
     "node_modules/@internationalized/number": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
-      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/string": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.8.tgz",
-      "integrity": "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -2802,9 +2710,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
-      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -2814,9 +2722,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2829,18 +2737,17 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
-      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/sdk-logs": "0.202.0",
-        "@opentelemetry/sdk-metrics": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1",
-        "protobufjs": "^7.3.0"
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2850,12 +2757,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
-      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/core": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2866,14 +2773,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
-      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1"
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2883,13 +2791,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
-      "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1"
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2899,13 +2807,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2916,9 +2824,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -3308,70 +3216,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@rc-component/cascader": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.9.0.tgz",
@@ -3405,12 +3249,12 @@
       }
     },
     "node_modules/@rc-component/motion": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.2.tgz",
-      "integrity": "sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.3.tgz",
+      "integrity": "sha512-Xh3IszxvlSv3/PLYFyC2UZi9LNB83yOnkB/LNmRzaypZLvkhqUIPS7MQpGZcCMWrNsXV2p6YTSWbSGvFpEle9A==",
       "license": "MIT",
       "dependencies": {
-        "@rc-component/util": "^1.2.0",
+        "@rc-component/util": "^1.11.0",
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
@@ -3473,12 +3317,12 @@
       }
     },
     "node_modules/@rc-component/portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
-      "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.1.tgz",
+      "integrity": "sha512-ck+r1kW/JSv0wxPji3KN2ss9K6Z0qqwusw/mf/0JobXhZ8hC2ejZwCJObW/SvDi0uhA0VzmCnx0CaCci95tcmA==",
       "license": "MIT",
       "dependencies": {
-        "@rc-component/util": "^1.2.1",
+        "@rc-component/util": "^1.11.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -3574,9 +3418,9 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
-      "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.1.tgz",
+      "integrity": "sha512-LNsYvz60mrLJ/kRvKcHE7boUvcQfVMCfRqZ71x3Fo9AOiZ1KKIEqkzMA8DNvz2V3Bcvir/vwQNn7JF1NPODQ7Q==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
@@ -3594,9 +3438,9 @@
       }
     },
     "node_modules/@rc-component/util": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.10.1.tgz",
-      "integrity": "sha512-q++9S6rUa5Idb/xIBNz6jtvumw5+O5YV5V0g4iK9mn9jWs4oGJheE3ZN1kAnE723AXyaD8v95yeOASmdk8Jnng==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.11.1.tgz",
+      "integrity": "sha512-awVlI3ub2vqfqkYxOBc/uQ0efm3jw0wcrhtO/YWLyZfxiKXczKwNbVuhlnyxytDt7H9pbbVQiqr+O6MLATtRYg==",
       "license": "MIT",
       "dependencies": {
         "is-mobile": "^5.0.0",
@@ -3608,9 +3452,9 @@
       }
     },
     "node_modules/@rc-component/virtual-list": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
-      "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.2.0.tgz",
+      "integrity": "sha512-iavRm1Jo4GDbASQwdGa7jFyk93RvSOo9xHyBT4QL1pgFJj/Fdf1G+3RErH7/7BmAMvx2AkF62mjGYxDbXsK9TQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
@@ -3622,18 +3466,18 @@
         "node": ">=8.x"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@react-aria/button": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.15.0.tgz",
-      "integrity": "sha512-p8KehQ+OmhvhYmsjkp4K/Yv0tufyEBOHu6woJlRYL6kq5m6GKY5MZp8pyO26FpSiOyjhnZe6wbTyvCifvaokwQ==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.15.1.tgz",
+      "integrity": "sha512-SBMn8ZLvjuWCpSqi6o1hOjsqQqkdYFfzIdl/0LgNPUpTclkJuMx7gNXfM3mjgxzSCoS5CD/XdicvqJanMw6jCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3676,16 +3520,16 @@
       }
     },
     "node_modules/@react-aria/i18n": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.13.0.tgz",
-      "integrity": "sha512-APjw4EwmvlnIyDxixSWfjHvOFFkW2rVTyKZ4l9FV0v7hOerh+FWLE6mF1XnnX3pgz3yARkKWwhSR9xYcRK6tpg==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.13.1.tgz",
+      "integrity": "sha512-z56ZYcbfpNmMyiGLhyEjytpmEfoTlBaksk84q4kds3HvNkf7QWKj+DJVfVDrJX+c1LyuBsszLSX7yxJRiHsYKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@internationalized/date": "^3.12.1",
         "@internationalized/message": "^3.1.9",
         "@internationalized/string": "^3.2.8",
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3693,14 +3537,14 @@
       }
     },
     "node_modules/@react-aria/interactions": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.0.tgz",
-      "integrity": "sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-types/shared": "^3.34.0",
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3731,13 +3575,13 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.0.tgz",
-      "integrity": "sha512-mnelvACtfNWWKFCT1YHebxJRmfBmmANGwHQhCFPByMVTx1L8RumcaLxChYkE87g2KPuP5xX2il/oRn1DytW+qQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.1.tgz",
+      "integrity": "sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
+        "react-aria": "^3.48.0"
       },
       "engines": {
         "node": ">= 12"
@@ -3766,13 +3610,13 @@
       }
     },
     "node_modules/@react-aria/visually-hidden": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.9.0.tgz",
-      "integrity": "sha512-OBSwuke98mVtd2po43VOT999rO9mpL7yaSehMuIylOT2wyY01Tut+ATpjavKbcZAust4eZFALVARYAS/0+GHyA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.9.1.tgz",
+      "integrity": "sha512-PWuth+NTmUiBJAIyrfk7dJ5BxOBupDt0iFGlBiYr5FElSYvwN9LAk1kgkzm6hT2qzq4FmYdQgBSPkGeaxOui6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3780,12 +3624,12 @@
       }
     },
     "node_modules/@react-spectrum/button": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@react-spectrum/button/-/button-3.18.0.tgz",
-      "integrity": "sha512-SmjsXt+mLK2cf8PGstNZvLBfjqE5TjHW15yPIATI6ddqMdcC9JZ3ldnBTdFji9P/B6Rlop4ajnAdDV6bpxLtXA==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/button/-/button-3.18.1.tgz",
+      "integrity": "sha512-FW+1d6zfKesMLaBrsRsnnYnsLfvf2qFKuatkCo62o1oGUBtEYI/kae+lwGwlfiX5q9P5OgR2y1IqKtxabf/JKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/react-spectrum": "3.47.0",
+        "@adobe/react-spectrum": "^3.47.0",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -3794,12 +3638,12 @@
       }
     },
     "node_modules/@react-spectrum/dialog": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@react-spectrum/dialog/-/dialog-3.10.0.tgz",
-      "integrity": "sha512-U+0rTx1eG+BIpIb3vUAtP/n65CsyGydhtkJSNDTGUzG8yHgc7jGU/siwhY6/C8Y25wU4QggkXhIcn0y6rLvJ4g==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dialog/-/dialog-3.10.1.tgz",
+      "integrity": "sha512-RMoZkKswUMFiEnAHZljEV1ybpMUjrS5RxkwWb3IFMo+ZtnLIeIT87k4DxoUJKOVrw3bnSsLRSTw1Fvf7jZ/eFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/react-spectrum": "3.47.0",
+        "@adobe/react-spectrum": "^3.47.0",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -3808,12 +3652,12 @@
       }
     },
     "node_modules/@react-spectrum/overlays": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@react-spectrum/overlays/-/overlays-5.10.0.tgz",
-      "integrity": "sha512-iGHXE5wdF4wNqdkgTKWAoeJUeKec+ki1BeRdiguywjY/SGMIx8Htd4dWyglDsOboBBJuEWMHKFAmTbMDhz6B9w==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/overlays/-/overlays-5.10.1.tgz",
+      "integrity": "sha512-VSpplRbzYA/Hmg+fR7fonj/Q3jq7mJHD6A5f189teX5/uRiTk7P4DogBYfU1a70BAq3xBEA4hV3QpA8i9pK8jQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/react-spectrum": "3.47.0",
+        "@adobe/react-spectrum": "^3.47.0",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -3822,13 +3666,13 @@
       }
     },
     "node_modules/@react-spectrum/provider": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@react-spectrum/provider/-/provider-3.11.0.tgz",
-      "integrity": "sha512-W2Gxbj8AcG5OR2K5Ua3K8qQqxdsiytEiz+2rhr6oQyBM8VafEgDcNPYSOTtfjrQM3snl2Uhp8LzwN0jwQe/6nQ==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/provider/-/provider-3.11.1.tgz",
+      "integrity": "sha512-TsoNdVdmlQ7L+75ILq5Yb3+wp/I1AtIeat0o+Y+ZBxP+TtWpwT1ZtCB5l3cplFVzHzOpZlzO0VaDrDP9ElGYDw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@adobe/react-spectrum": "3.47.0",
+        "@adobe/react-spectrum": "^3.47.0",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -3837,13 +3681,13 @@
       }
     },
     "node_modules/@react-stately/flags": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.2.0.tgz",
-      "integrity": "sha512-HcfFk5sUpSVUgjOHUSi4izUWbiya+iTt2/PAviW+cKmCJOy507CQ3VG3Yu0Rqs0cr66yt3foDKy0MRNQ2zmGmQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.2.1.tgz",
+      "integrity": "sha512-WPw9z4SPYqQMuExCnBNrQyyxCWSi9CDYnVqca19bqxaHZRT/uL5nL+IGCPHHa70Y5rx39E5hYKl8Hf0QJ6XKyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-stately": "3.46.0"
+        "react-stately": "^3.46.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3851,13 +3695,13 @@
       }
     },
     "node_modules/@react-stately/overlays": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.7.0.tgz",
-      "integrity": "sha512-VyFlju6JqEUTyr+igrEjTeUi2MXw7IBOxWYzLoq26UJxf+45okqUWfyKRdXTvNjGJqQol9fqIg5Nv8fU4H/CvQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.7.1.tgz",
+      "integrity": "sha512-vGw9f8i5kPvaQqvvQ8iIhPhJZorwtg2rXycqnUNXkNLadewh1S0ocbnRvrb4HW/GGC37rFmGcG1fYCHA/WIn6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-stately": "3.46.0"
+        "react-stately": "^3.46.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3865,13 +3709,13 @@
       }
     },
     "node_modules/@react-stately/utils": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.12.0.tgz",
-      "integrity": "sha512-7q+iHz9cENvro1dVKgdTxNh1i1mtWuLUI6UHp10TAgpxM9DyRDvmuN35zLXYCmMDgx3WLY2xkwqoez8xd+CdxQ==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.12.1.tgz",
+      "integrity": "sha512-NqKfzrknpfwiewx7R2vk1P+CneClInPDsIhw15+jOcUYSEfej0nta4cJywuKQJ2gsPwqX/ojDNixedCve9FWGw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-stately": "3.46.0"
+        "react-stately": "^3.46.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3909,13 +3753,13 @@
       }
     },
     "node_modules/@react-types/dialog/node_modules/@react-aria/dialog": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.6.0.tgz",
-      "integrity": "sha512-FL7mInToLqYHCQExAj5fg1kpF5H4q0CvBs9GKZAo0HCWVv9pb5i4SiN1FXm5CJWU62UIhd7JysdW3Jl+TXtSng==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.6.1.tgz",
+      "integrity": "sha512-Eo3Kj23TjENuERUYrGkH+VN1PJvK8/zep76pfwBg29erUVDpGdfagYRq82aGcxJ/ohG8iRxZDwp2tTrU1RG1MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3940,13 +3784,13 @@
       }
     },
     "node_modules/@react-types/overlays/node_modules/@react-aria/overlays": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.32.0.tgz",
-      "integrity": "sha512-H9meBB14/M0bDwk8gZl8Fu8bwZN2El9LDlk5cNkgAozbEiRuQvTFOeE3RoP6XI6bwEnSBvb0ovPmx3/kNyOehQ==",
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.32.1.tgz",
+      "integrity": "sha512-jjVLcEK5qaGsz3SmW+eLV3QFiJzdDFzgNofPwvzBS1KTPox0a2x5u1ITUPmHwyUNiyexy531h5eVjN3tULEzHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3954,18 +3798,18 @@
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
-      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.35.0.tgz",
+      "integrity": "sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -4012,9 +3856,9 @@
       }
     },
     "node_modules/@spectrum-icons/ui": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-icons/ui/-/ui-3.7.0.tgz",
-      "integrity": "sha512-86iQSDfJb3Ama1WSJ/mEiFy4DJT7e/v4pSmEuX4aKKMzbNYft+O40N18S2POUnmblrb7MQneLC/pgIp1SDBwEQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/ui/-/ui-3.7.1.tgz",
+      "integrity": "sha512-veQymocUYo5OciXQajSailOdbWe+k6+2ehfF8D4d0V923D4xOUadtT253xXZ5vEQjPat6Kyp2WDKeQNjd7kL1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum-ui": "1.2.1",
@@ -4028,9 +3872,9 @@
       }
     },
     "node_modules/@spectrum-icons/workflow": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-icons/workflow/-/workflow-4.3.0.tgz",
-      "integrity": "sha512-ILuhgWh9jMXaEVMRuOYgTAjMc22cKyvCtUDyZmc8OEMfOYuejj+Gcp5t6DhaCfE0M9rORtVxCrRgsO2WyEgfUw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/workflow/-/workflow-4.3.1.tgz",
+      "integrity": "sha512-kDF+/EbFVyLGytotqqdYt4uSij4j/PQmDQO5km/C6DyzKjyuic3FnSBFinR+mA6oFv1OjMcLvrrDBqK3wbqRlA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum-workflow": "2.3.5",
@@ -4389,12 +4233,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.24",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
-      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.14.0"
+        "@tanstack/virtual-core": "3.17.1"
       },
       "funding": {
         "type": "github",
@@ -4406,9 +4250,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
-      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4733,6 +4577,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -7397,18 +7242,21 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/downshift": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.2.tgz",
-      "integrity": "sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.6.tgz",
+      "integrity": "sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -9261,9 +9109,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -11307,12 +11155,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12538,30 +12380,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
-    "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
@@ -12726,19 +12544,19 @@
       }
     },
     "node_modules/react-aria": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.48.0.tgz",
-      "integrity": "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.49.0.tgz",
+      "integrity": "sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.1",
-        "@internationalized/number": "^3.6.6",
-        "@internationalized/string": "^3.2.8",
-        "@react-types/shared": "^3.34.0",
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.35.0",
         "@swc/helpers": "^0.5.0",
         "aria-hidden": "^1.2.3",
         "clsx": "^2.0.0",
-        "react-stately": "3.46.0",
+        "react-stately": "3.47.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -12747,17 +12565,17 @@
       }
     },
     "node_modules/react-aria-components": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.17.0.tgz",
-      "integrity": "sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.18.0.tgz",
+      "integrity": "sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.1",
-        "@react-types/shared": "^3.34.0",
+        "@internationalized/date": "^3.12.2",
+        "@react-types/shared": "^3.35.0",
         "@swc/helpers": "^0.5.0",
         "client-only": "^0.0.1",
-        "react-aria": "3.48.0",
-        "react-stately": "3.46.0"
+        "react-aria": "3.49.0",
+        "react-stately": "3.47.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -12814,19 +12632,6 @@
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-data-grid": {
-      "version": "7.0.0-beta.56",
-      "resolved": "git+ssh://git@github.com/grafana/react-data-grid.git#a10c748f40edc538425b458af4e471a8262ec4ed",
-      "integrity": "sha512-ysx8WSmQGqxIWmgBIJuu+VHVmTK5sGfx522hipRW4V/7x7dwF/ikrvlvhpu2z5riNl5O3wEoMVtqnQSAkHOKDA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0 || ^19.0",
-        "react-dom": "^18.0 || ^19.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -12880,9 +12685,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
-      "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.79.0.tgz",
+      "integrity": "sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -12935,9 +12740,9 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -12996,14 +12801,14 @@
       }
     },
     "node_modules/react-router-dom-v5-compat": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.3.tgz",
-      "integrity": "sha512-WWZtwGYyoaeUDNrhzzDkh4JvN5nU0MIz80Dxim6pznQrfS+dv0mvtVoHTA6HlUl/OiJl7WWjbsQwjTnYXejEHg==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.4.tgz",
+      "integrity": "sha512-lJP6Zl6DYQtmrnaOV7MW5s/Npe7mYOokwekaPAqjCgIMQmZFfdA8mfoe5kWJoT/xedSdgZLrfFVHx18RUIIcEw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
+        "@remix-run/router": "1.23.3",
         "history": "^5.3.0",
-        "react-router": "6.30.3"
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -13024,12 +12829,12 @@
       }
     },
     "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -13072,15 +12877,15 @@
       "license": "MIT"
     },
     "node_modules/react-stately": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.46.0.tgz",
-      "integrity": "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.47.0.tgz",
+      "integrity": "sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.1",
-        "@internationalized/number": "^3.6.6",
-        "@internationalized/string": "^3.2.8",
-        "@react-types/shared": "^3.34.0",
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.35.0",
         "@swc/helpers": "^0.5.0",
         "use-sync-external-store": "^1.6.0"
       },
@@ -13574,13 +13379,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/sass/node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -15158,6 +14956,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -15392,9 +15191,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
     "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -74,11 +74,11 @@
   },
   "dependencies": {
     "@emotion/css": "11.13.5",
-    "@grafana/data": "^12.4.2",
-    "@grafana/i18n": "^12.4.2",
-    "@grafana/runtime": "^12.4.2",
-    "@grafana/schema": "^12.3.1",
-    "@grafana/ui": "^12.3.1",
+    "@grafana/data": "^13.0.1",
+    "@grafana/i18n": "^13.0.1",
+    "@grafana/runtime": "^13.0.1",
+    "@grafana/schema": "^13.0.1",
+    "@grafana/ui": "^13.0.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },


### PR DESCRIPTION
## Summary
- Bumps all `@grafana/*` runtime packages to `^13.0.1` together: `data`, `runtime`, `i18n`, `schema`, `ui` (resolves to 13.0.2, fully deduped).
- No source changes needed - the plugin's API usage is Grafana 13 compatible.
- Supersedes the partial Dependabot PRs #128, #129, #130, which break the build individually because `@grafana/ui` and `@grafana/schema` stayed at `^12`.

## Verification (all green locally)
- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm run test:ci` (143 passed)
- `npm run build`

## Follow-up
Close #128, #129, #130 in favor of this combined bump.