### PR TITLE
fix(ci): revert e2e-version action to v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v3.0.0
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v2.0.0
 
   playwright-tests:
     needs: [ resolve-versions, build ]


### PR DESCRIPTION
## Problem
The `Resolve e2e images` job on `main` fails immediately:

```
/home/runner/work/_actions/grafana/plugin-actions/e2e-version/v3.0.0/e2e-version/dist/index.js:2
... uncaught exception inside the action bundle (undici/fetch) ...
```

PR #135 bumped `grafana/plugin-actions/e2e-version` from `v2.0.0` to `v3.0.0`. `v3.0.0` is the only v3 tag, is brand new, runs on `node24`, and crashes with an uncaught error before resolving any versions. There is no `v3.0.1` fix yet.

## Fix
Revert that single action to the proven `v2.0.0`. No other changes. The other two action bumps from this batch (`wait-for-grafana@v1.0.4`, `codecov-action@v7`) are unaffected and kept.

## Follow-up
Dependabot will re-propose the v3 bump; revisit once upstream ships a working `v3.0.x`.