### PR TITLE
ci(codeql): bump codeql-action init and analyze to v4.37.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,13 +30,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Bumps both `github/codeql-action/init` and `github/codeql-action/analyze` to the same SHA (v4.37.1, `7188fc3`).

Supersedes #162 and #164, which each bumped only one of the two actions and failed with:
`Loaded a configuration file for version '4.37.1', but running version '4.36.2'` — CodeQL requires init and analyze to be the same version.

Closes #162
Closes #164