### PR TITLE
fix(utils): validate queries by buildQuery capability

### DIFF
--- a/src/components/DynamicSearchPanel.spec.tsx
+++ b/src/components/DynamicSearchPanel.spec.tsx
@@ -217,14 +217,11 @@ describe('DynamicSearchPanel', () => {
         expect(mockMetricFindQuery).not.toHaveBeenCalled();
     });
 
-    it('does not crash when buildQuery returns empty string', async () => {
+    it('flags queries that cannot build a query as invalid configuration', async () => {
         render(<DynamicSearchPanel {...defaultProps} options={{ ...defaultOptions, queries: [{ id: 'q-1', queryType: 'invalid' as any, metric: 'up' }] }} />);
-        
-        const input = await screen.findByTestId('combobox-input');
-        fireEvent.change(input, { target: { value: 'test' } });
-        
-        // Should just return empty list, not crash
-        await waitFor(() => {}, { timeout: 100 });
+
+        expect(await screen.findByText('At least one valid query (check metric and label fields)')).toBeInTheDocument();
+        expect(screen.queryByTestId('combobox-input')).not.toBeInTheDocument();
     });
 
     it('handles metricFindQuery failure gracefully', async () => {

--- a/src/components/QueriesEditor.tsx
+++ b/src/components/QueriesEditor.tsx
@@ -224,13 +224,19 @@ const QueriesEditorComponent: React.FC<Props> = ({ value, onChange }) => {
             )}
 
             <div className={styles.fieldRow}>
-              <label className={styles.fieldLabel}>Metric *</label>
+              <label className={styles.fieldLabel}>
+                {query.queryType === QUERY_TYPE.LABEL_VALUES ? 'Metric' : 'Metric (optional)'}
+              </label>
               <Input
                 value={query.metric}
                 onChange={(e) =>
                   updateQuery(index, { metric: e.currentTarget.value })
                 }
-                placeholder="e.g., up, http_requests_total"
+                placeholder={
+                  query.queryType === QUERY_TYPE.LABEL_VALUES
+                    ? 'e.g., up, http_requests_total'
+                    : 'Leave empty to list all'
+                }
               />
             </div>
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -276,24 +276,36 @@ describe('utils', () => {
   });
 
   describe('isQueryValid', () => {
-    it('should return false if metric is empty', () => {
-      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.METRICS, metric: '', name: '' })).toBe(false);
-    });
-
-    it('should return false for label_values without label', () => {
-      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_VALUES, metric: 'up', label: '', name: '' })).toBe(false);
-    });
-
-    it('should return true for label_values with metric and label', () => {
-      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_VALUES, metric: 'up', label: 'job', name: '' })).toBe(true);
+    it('should return true for metrics query without metric', () => {
+      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.METRICS, metric: '', name: '' })).toBe(true);
     });
 
     it('should return true for metrics query with metric', () => {
       expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.METRICS, metric: '.*', name: '' })).toBe(true);
     });
 
+    it('should return true for label_names without metric', () => {
+      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_NAMES, metric: '', name: '' })).toBe(true);
+    });
+
     it('should return true for label_names with metric', () => {
       expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_NAMES, metric: 'up', name: '' })).toBe(true);
+    });
+
+    it('should return true for label_values with only label', () => {
+      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_VALUES, metric: '', label: 'job', name: '' })).toBe(true);
+    });
+
+    it('should return true for label_values with metric and label', () => {
+      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_VALUES, metric: 'up', label: 'job', name: '' })).toBe(true);
+    });
+
+    it('should return false for label_values without label', () => {
+      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_VALUES, metric: 'up', label: '', name: '' })).toBe(false);
+    });
+
+    it('should return false for an unknown query type', () => {
+      expect(isQueryValid({ id: '1', queryType: 'invalid' as QueryType, metric: 'up', name: '' })).toBe(false);
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,15 +95,8 @@ export const applyRegexTransform = (
   return result;
 };
 
-/** Validates that a query config has the minimum required fields */
 export const isQueryValid = (q: QueryConfig): boolean => {
-  if (!q.metric) {
-    return false;
-  }
-  if (q.queryType === QUERY_TYPE.LABEL_VALUES && !q.label) {
-    return false;
-  }
-  return true;
+  return buildQuery({ queryType: q.queryType, label: q.label, metric: q.metric }) !== '';
 };
 
 export const getInitialVariableValue = (variableName: string | undefined): SelectableValue<string> | null => {


### PR DESCRIPTION
## Summary
- `isQueryValid` now accepts any config that `buildQuery` can turn into a non-empty query: metric-less `label_names()`, `metrics(.*)`, and `label_values(label)`.
- `QueriesEditor` no longer marks **Metric** as required; the label/placeholder now reflect per-type optionality.
- Updated `utils.spec.ts` validity matrix and one `DynamicSearchPanel` test (an unknown query type is now correctly flagged as invalid configuration).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:ci` (146 passed)
- [x] `npm run build`
- [ ] `npm run e2e` (couldn't run locally — port 3000 is your SSH tunnel to a remote Grafana; CI will run it)