### PR TITLE
perf(utils): add ReDoS guards and centralize regex handling

### DIFF
--- a/src/components/DynamicSearchPanel.spec.tsx
+++ b/src/components/DynamicSearchPanel.spec.tsx
@@ -477,6 +477,35 @@ describe('DynamicSearchPanel - Multi-Query', () => {
 
         consoleSpy.mockRestore();
     });
+
+    it('should warn and skip transformation when a per-query regex is invalid', async () => {
+        const mockMetricFindQuery = jest.fn().mockResolvedValue([
+            { text: 'pod-01', value: 'pod-01' },
+        ]);
+        mockGetDataSourceSrv.mockReturnValue({
+            metricFindQuery: mockMetricFindQuery,
+        });
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const invalidRegexOptions: SimpleOptions = {
+            ...defaultOptions,
+            queries: [
+                { id: 'q-1', queryType: 'label_values', label: 'pod', metric: 'up', regex: '(' },
+            ],
+            maxResults: 0,
+        };
+
+        render(<DynamicSearchPanel {...defaultProps} options={invalidRegexOptions} />);
+        const input = screen.getByTestId('combobox-input');
+        fireEvent.change(input, { target: { value: 'pod' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('option-pod-01')).toBeInTheDocument();
+        });
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid regex in query'));
+
+        consoleSpy.mockRestore();
+    });
 });
 
 describe('DynamicSearchPanel - Debounce Effectiveness', () => {

--- a/src/components/QueriesEditor.tsx
+++ b/src/components/QueriesEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { SimpleOptions, QueryConfig, QUERY_TYPE, QueryType } from '../types';
-import { generateQueryId, buildQuery } from '../utils';
+import { generateQueryId, buildQuery, compileRegex } from '../utils';
 
 const queryTypeOptions = [
   { value: QUERY_TYPE.LABEL_VALUES as QueryType, label: 'Label values' },
@@ -250,17 +250,16 @@ const QueriesEditorComponent: React.FC<Props> = ({ value, onChange }) => {
                 placeholder="e.g., ^/api/(.*)"
               />
               {query.regex && (() => {
-                try {
-                  new RegExp(query.regex);
+                const { error } = compileRegex(query.regex);
+                if (!error) {
                   return null;
-                } catch (e) {
-                  return (
-                    <div className={styles.regexError} data-testid={`query-regex-error-${index}`}>
-                      <Icon name="exclamation-triangle" size="sm" />
-                      <span>Invalid regex: {(e as Error).message}</span>
-                    </div>
-                  );
                 }
+                return (
+                  <div className={styles.regexError} data-testid={`query-regex-error-${index}`}>
+                    <Icon name="exclamation-triangle" size="sm" />
+                    <span>Invalid regex: {error}</span>
+                  </div>
+                );
               })()}
             </div>
 

--- a/src/components/RegexEditor.spec.tsx
+++ b/src/components/RegexEditor.spec.tsx
@@ -81,7 +81,7 @@ describe('RegexEditor', () => {
     });
 
     it('shows test preview section when valid regex is entered', () => {
-        render(<RegexEditor {...defaultProps} value="node-(\d+)" />);
+        render(<RegexEditor {...defaultProps} value={'node-(\\d+)'} />);
         
         expect(screen.getByText('Test your regex:')).toBeInTheDocument();
         expect(screen.getByPlaceholderText('Enter a sample value to test')).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('RegexEditor', () => {
     });
 
     it('shows match result when test value matches regex with capture group', () => {
-        render(<RegexEditor {...defaultProps} value="node-(\d+)" />);
+        render(<RegexEditor {...defaultProps} value={'node-(\\d+)'} />);
         
         const testInput = screen.getByPlaceholderText('Enter a sample value to test');
         fireEvent.change(testInput, { target: { value: 'node-01' } });
@@ -118,7 +118,7 @@ describe('RegexEditor', () => {
     });
 
     it('shows no match when test value does not match regex', () => {
-        render(<RegexEditor {...defaultProps} value="node-(\d+)" />);
+        render(<RegexEditor {...defaultProps} value={'node-(\\d+)'} />);
         
         const testInput = screen.getByPlaceholderText('Enter a sample value to test');
         fireEvent.change(testInput, { target: { value: 'other-value' } });
@@ -127,7 +127,7 @@ describe('RegexEditor', () => {
     });
 
     it('does not show preview result when test input is empty', () => {
-        render(<RegexEditor {...defaultProps} value="node-(\d+)" />);
+        render(<RegexEditor {...defaultProps} value={'node-(\\d+)'} />);
         
         expect(screen.queryByText('No match')).not.toBeInTheDocument();
     });

--- a/src/components/RegexEditor.tsx
+++ b/src/components/RegexEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, memo } from 'react';
 import { StandardEditorProps, GrafanaTheme2 } from '@grafana/data';
 import { Input, useStyles2, Icon, TextArea } from '@grafana/ui';
 import { css, keyframes } from '@emotion/css';
+import { compileRegex, safeMatch } from '../utils';
 
 const fadeIn = keyframes`
   from { opacity: 0; }
@@ -84,34 +85,23 @@ interface ValidationResult {
 }
 
 const validateRegex = (pattern: string): ValidationResult => {
-  if (!pattern) {
-    return { valid: true, error: null };
-  }
-  try {
-    new RegExp(pattern);
-    return { valid: true, error: null };
-  } catch (e) {
-    return { valid: false, error: (e as Error).message };
-  }
+  const { error } = compileRegex(pattern);
+  return { valid: error === null, error };
 };
 
 const applyTestRegex = (pattern: string, testValue: string): string | null => {
   if (!pattern || !testValue) {
     return null;
   }
-  try {
-    const regex = new RegExp(pattern);
-    const match = testValue.match(regex);
-    if (match && match[1]) {
-      return match[1];
-    }
-    if (match) {
-      return match[0];
-    }
-    return null;
-  } catch {
-    return null;
+  const { regex } = compileRegex(pattern);
+  const match = safeMatch(testValue, regex);
+  if (match && match[1]) {
+    return match[1];
   }
+  if (match) {
+    return match[0];
+  }
+  return null;
 };
 
 const RegexEditorComponent: React.FC<StandardEditorProps<string>> = ({ value, onChange }) => {

--- a/src/hooks/useDynamicSearch.ts
+++ b/src/hooks/useDynamicSearch.ts
@@ -5,6 +5,7 @@ import { SimpleOptions, SEARCH_MODE, QueryConfig, TransformedMetricFindValue, DE
 import {
   buildQuery,
   applyRegexTransform,
+  compileRegex,
   deduplicateQueries,
   deduplicateResults,
   isQueryValid,
@@ -57,16 +58,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
     };
   }, []);
 
-  const compiledRegex = useMemo(() => {
-    if (!regex) {
-      return { regex: null, error: null };
-    }
-    try {
-      return { regex: new RegExp(regex), error: null };
-    } catch (e) {
-      return { regex: null, error: (e as Error).message };
-    }
-  }, [regex]);
+  const compiledRegex = useMemo(() => compileRegex(regex), [regex]);
 
   const compiledRegexRef = useRef(compiledRegex);
 
@@ -151,11 +143,11 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
             const queryPromise = ds.metricFindQuery!(queryStr, {}).then((results) => {
               let activeRegex: RegExp | null = null;
               if (queryConfig.regex) {
-                  try {
-                      activeRegex = new RegExp(queryConfig.regex);
-                  } catch (e) {
-                      console.warn(`Invalid regex in query "${queryName}":`, e);
+                  const compiled = compileRegex(queryConfig.regex);
+                  if (compiled.error) {
+                      console.warn(`Invalid regex in query "${queryName}": ${compiled.error}`);
                   }
+                  activeRegex = compiled.regex;
               } else {
                   activeRegex = compiledRegexRef.current.regex;
               }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { buildQuery, applyRegexTransform, deduplicateQueries, deduplicateResults, generateQueryId, isQueryValid, getInitialVariableValue, resolveDatasourceUid } from './utils';
+import { buildQuery, applyRegexTransform, compileRegex, safeMatch, MAX_REGEX_PATTERN_LENGTH, MAX_REGEX_INPUT_LENGTH, deduplicateQueries, deduplicateResults, generateQueryId, isQueryValid, getInitialVariableValue, resolveDatasourceUid } from './utils';
 import { QueryOptions, QueryType, QueryConfig, QUERY_TYPE } from './types';
 import { MetricFindValue } from '@grafana/data';
 
@@ -158,6 +158,67 @@ describe('utils', () => {
         const regex = /node-(\d+)/;
         const result = applyRegexTransform(valuesWithDescription, regex);
         expect(result[0]).toEqual({ text: '01', value: '01', description: 'First node', __originalText: 'node-01' });
+    });
+  });
+
+  describe('compileRegex', () => {
+    it('should return null regex and null error for empty pattern', () => {
+      expect(compileRegex('')).toEqual({ regex: null, error: null });
+      expect(compileRegex(undefined)).toEqual({ regex: null, error: null });
+      expect(compileRegex(null)).toEqual({ regex: null, error: null });
+    });
+
+    it('should compile a valid pattern', () => {
+      const { regex, error } = compileRegex('^node-(\\d+)$');
+      expect(regex).toBeInstanceOf(RegExp);
+      expect(error).toBeNull();
+    });
+
+    it('should return an error for an invalid pattern', () => {
+      const { regex, error } = compileRegex('(unclosed');
+      expect(regex).toBeNull();
+      expect(error).toEqual(expect.any(String));
+    });
+
+    it('should reject patterns longer than the maximum length', () => {
+      const longPattern = 'a'.repeat(MAX_REGEX_PATTERN_LENGTH + 1);
+      const { regex, error } = compileRegex(longPattern);
+      expect(regex).toBeNull();
+      expect(error).toContain('maximum length');
+    });
+  });
+
+  describe('safeMatch', () => {
+    it('should return null when regex is null', () => {
+      expect(safeMatch('anything', null)).toBeNull();
+    });
+
+    it('should return capture groups for a matching pattern', () => {
+      const match = safeMatch('node-42', /node-(\d+)/);
+      expect(match?.[1]).toBe('42');
+    });
+
+    it('should return null when there is no match', () => {
+      expect(safeMatch('abc', /\d+/)).toBeNull();
+    });
+
+    it('should cap the tested input length', () => {
+      const oversized = 'a'.repeat(MAX_REGEX_INPUT_LENGTH + 5000);
+      const match = safeMatch(oversized, /^a+/);
+      expect(match?.[0].length).toBe(MAX_REGEX_INPUT_LENGTH);
+    });
+
+    it('should return safely and without hanging on a pathological pattern', () => {
+      const evil = '(a+)+$'.repeat(300);
+      const { regex } = compileRegex(evil);
+      expect(regex).toBeNull();
+
+      const start = performance.now();
+      const result = safeMatch('a'.repeat(50000) + '!', regex);
+      const elapsed = performance.now() - start;
+
+      expect(result).toBeNull();
+      expect(elapsed).toBeLessThan(100);
     });
   });
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -208,15 +208,24 @@ describe('utils', () => {
       expect(match?.[0].length).toBe(MAX_REGEX_INPUT_LENGTH);
     });
 
-    it('should return safely and without hanging on a pathological pattern', () => {
-      const evil = '(a+)+$'.repeat(300);
-      const { regex } = compileRegex(evil);
+    it('should not throw when matching raises an error', () => {
+      const throwing = {
+        [Symbol.match]() {
+          throw new Error('boom');
+        },
+      } as unknown as RegExp;
+      expect(safeMatch('anything', throwing)).toBeNull();
+    });
+
+    it('should neutralize an over-length pattern before it can execute', () => {
+      const pathological = 'a'.repeat(MAX_REGEX_PATTERN_LENGTH + 1);
+      const { regex, error } = compileRegex(pathological);
       expect(regex).toBeNull();
+      expect(error).toContain('maximum length');
 
       const start = performance.now();
-      const result = safeMatch('a'.repeat(50000) + '!', regex);
+      const result = safeMatch('a'.repeat(50000), regex);
       const elapsed = performance.now() - start;
-
       expect(result).toBeNull();
       expect(elapsed).toBeLessThan(100);
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,28 +67,60 @@ export const deduplicateResults = <T extends { text?: string }>(results: T[]): T
   return deduplicated;
 };
 
+export const MAX_REGEX_PATTERN_LENGTH = 1000;
+export const MAX_REGEX_INPUT_LENGTH = 10000;
+
+export interface CompiledRegex {
+  regex: RegExp | null;
+  error: string | null;
+}
+
+export const compileRegex = (pattern: string | undefined | null): CompiledRegex => {
+  if (!pattern) {
+    return { regex: null, error: null };
+  }
+  if (pattern.length > MAX_REGEX_PATTERN_LENGTH) {
+    return {
+      regex: null,
+      error: `Pattern exceeds maximum length of ${MAX_REGEX_PATTERN_LENGTH} characters`,
+    };
+  }
+  try {
+    return { regex: new RegExp(pattern), error: null };
+  } catch (e) {
+    return { regex: null, error: (e as Error).message };
+  }
+};
+
+export const safeMatch = (text: string, regex: RegExp | null): RegExpMatchArray | null => {
+  if (!regex) {
+    return null;
+  }
+  const capped = text.length > MAX_REGEX_INPUT_LENGTH ? text.slice(0, MAX_REGEX_INPUT_LENGTH) : text;
+  try {
+    return capped.match(regex);
+  } catch {
+    return null;
+  }
+};
+
 export const applyRegexTransform = (
   values: MetricFindValue[],
   regex: RegExp | null
 ): TransformedMetricFindValue[] => {
-  const len = values.length;
-
   if (!regex) {
     return values;
   }
 
+  const len = values.length;
   const result = new Array<TransformedMetricFindValue>(len);
   for (let i = 0; i < len; i++) {
     const item = values[i];
     const text = item.text ?? '';
-    try {
-      const match = text.match(regex);
-      if (match && match[1]) {
-        result[i] = { ...item, text: match[1], value: match[1], __originalText: text };
-      } else {
-        result[i] = item;
-      }
-    } catch {
+    const match = safeMatch(text, regex);
+    if (match && match[1]) {
+      result[i] = { ...item, text: match[1], value: match[1], __originalText: text };
+    } else {
       result[i] = item;
     }
   }


### PR DESCRIPTION
## Summary
- New `compileRegex(pattern)` / `safeMatch(text, regex)` in `utils.ts`: reject overly long patterns (>1000 chars), cap matched input length (10000 chars), and never throw.
- Replaced 4 duplicated regex implementations (hook global + per-query regex, `RegexEditor` validate/preview, `QueriesEditor` inline validity check) with the shared helpers.
- `applyRegexTransform` now matches via `safeMatch`.

## Notes
- Input-length and pattern-length caps neutralize the common super-linear/oversized-input ReDoS vectors. The configured regex comes from the panel author (not end-user input), so this bounds the practical attack surface. Full immunity to crafted exponential patterns would require a non-backtracking engine (RE2) and is out of scope.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:ci` (155 passed; +9 guard tests)
- [x] `npm run build`
- [ ] `npm run e2e` (not in the e2e-required set; CI e2e matrix will run on push)