### PR TITLE
refactor(hook): remove dead AbortController from useDynamicSearch

### DIFF
--- a/src/components/DynamicSearchPanel.spec.tsx
+++ b/src/components/DynamicSearchPanel.spec.tsx
@@ -203,6 +203,26 @@ describe('DynamicSearchPanel', () => {
         expect(screen.getByTestId('option-node-02')).toBeInTheDocument();
     });
 
+    it('clears the loading indicator after a search resolves', async () => {
+        const mockMetricFindQuery = jest.fn().mockResolvedValue([
+            { text: 'node-01', value: 'node-01' },
+        ]);
+        mockGetDataSourceSrv.mockReturnValue({
+            metricFindQuery: mockMetricFindQuery,
+        });
+
+        render(<DynamicSearchPanel {...defaultProps} />);
+        const input = screen.getByTestId('combobox-input');
+        fireEvent.change(input, { target: { value: 'node' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('option-node-01')).toBeInTheDocument();
+        });
+        await waitFor(() => {
+            expect(screen.queryByTestId('dynamic-search-panel-loading')).not.toBeInTheDocument();
+        });
+    });
+
     it('does not fetch options when input is too short', async () => {
         const mockMetricFindQuery = jest.fn();
         mockGetDataSourceSrv.mockReturnValue({
@@ -253,6 +273,21 @@ describe('DynamicSearchPanel', () => {
         await waitFor(() => {}); 
         const options = screen.queryAllByTestId(/^option-/);
         expect(options).toHaveLength(0);
+    });
+
+    it('handles datasource resolution failure gracefully', async () => {
+        mockGetDataSourceSrv.mockRejectedValue(new Error('datasource unavailable'));
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(<DynamicSearchPanel {...defaultProps} />);
+        const input = screen.getByTestId('combobox-input');
+        fireEvent.change(input, { target: { value: 'test' } });
+
+        await waitFor(() => {
+            expect(consoleSpy).toHaveBeenCalledWith('Failed to load options:', expect.any(Error));
+        });
+        expect(screen.queryByTestId('dynamic-search-panel-loading')).not.toBeInTheDocument();
+        consoleSpy.mockRestore();
     });
 
     it('filters results based on input', async () => {
@@ -716,7 +751,7 @@ describe('DynamicSearchPanel - Cleanup', () => {
         expect(() => unmount()).not.toThrow();
     });
 
-    it('should abort pending requests on unmount', async () => {
+    it('should discard pending requests on unmount without errors', async () => {
         const mockMetricFindQuery = jest.fn().mockImplementation(() => {
             return new Promise((resolve) => {
                 setTimeout(() => resolve([{ text: 'result', value: 'result' }]), 1000);

--- a/src/hooks/useDynamicSearch.ts
+++ b/src/hooks/useDynamicSearch.ts
@@ -34,7 +34,6 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
   const [lastResultCount, setLastResultCount] = useState<number | null>(null);
   const [failedQueries, setFailedQueries] = useState<string[]>([]);
 
-  const abortControllerRef = useRef<AbortController | null>(null);
   const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const debounceResolveRef = useRef<((value: boolean) => void) | null>(null);
   const requestIdRef = useRef(0);
@@ -47,7 +46,6 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
 
   useEffect(() => {
     return () => {
-      abortControllerRef.current?.abort();
       if (debounceTimeoutRef.current) {
         clearTimeout(debounceTimeoutRef.current);
       }
@@ -68,7 +66,6 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
 
   const loadOptions = useCallback(
     async (inputValue: string): Promise<Array<{ label: string; value: string; description?: string }>> => {
-      abortControllerRef.current?.abort();
       if (debounceTimeoutRef.current) {
         clearTimeout(debounceTimeoutRef.current);
         debounceTimeoutRef.current = null;
@@ -112,11 +109,10 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
         }
 
         setIsLoading(true);
-        abortControllerRef.current = new AbortController();
         try {
           const ds = await getDataSourceSrv().get(resolvedDatasourceUid);
 
-          if (currentRequestId !== requestIdRef.current || abortControllerRef.current?.signal.aborted) {
+          if (currentRequestId !== requestIdRef.current) {
             return [];
           }
 
@@ -178,7 +174,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
 
           const allSettled = await Promise.all(queryPromises);
 
-          if (currentRequestId !== requestIdRef.current || abortControllerRef.current?.signal.aborted) {
+          if (currentRequestId !== requestIdRef.current) {
             return [];
           }
 
@@ -231,7 +227,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
             })
             .filter((r) => typeof r.value === 'string' && r.value !== '');
         } catch (err) {
-          if (currentRequestId !== requestIdRef.current || abortControllerRef.current?.signal.aborted) {
+          if (currentRequestId !== requestIdRef.current) {
             return [];
           }
           console.error('Failed to load options:', err);


### PR DESCRIPTION
## Summary
- Removed the unused `AbortController` (recreated per call, never wired to cancellation) and its `.aborted` checks.
- Request staleness now relies solely on `requestIdRef`, the mechanism that already discards superseded results.
- Confirmed `setIsLoading(false)` on all terminal early-returns; stale returns intentionally leave loading to the newer owning request.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:ci` (159 passed)
- [x] `npm run build`
- [x] coverage 95.13% (project +; patch lines covered)