### PR TITLE
refactor(hook): dedup key util, drop O(n^2) indexOf, memoize per-query regex

### DIFF
--- a/src/components/QueriesEditor.tsx
+++ b/src/components/QueriesEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { SimpleOptions, QueryConfig, QUERY_TYPE, QueryType } from '../types';
-import { generateQueryId, buildQuery, compileRegex } from '../utils';
+import { generateQueryId, buildQuery, compileRegex, queryDedupKey } from '../utils';
 
 const queryTypeOptions = [
   { value: QUERY_TYPE.LABEL_VALUES as QueryType, label: 'Label values' },
@@ -113,7 +113,7 @@ const QueriesEditorComponent: React.FC<Props> = ({ value, onChange }) => {
     const seen = new Map<string, number>();
     const dupes = new Set<number>();
     queries.forEach((q, idx) => {
-      const key = `${q.queryType}|${q.label ?? ''}|${q.metric}|${q.queryTimeout ?? ''}`;
+      const key = queryDedupKey(q);
       if (seen.has(key)) {
         dupes.add(seen.get(key)!);
         dupes.add(idx);

--- a/src/hooks/useDynamicSearch.ts
+++ b/src/hooks/useDynamicSearch.ts
@@ -6,6 +6,7 @@ import {
   buildQuery,
   applyRegexTransform,
   compileRegex,
+  CompiledRegex,
   deduplicateQueries,
   deduplicateResults,
   isQueryValid,
@@ -63,6 +64,22 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
   useEffect(() => {
     compiledRegexRef.current = compiledRegex;
   }, [compiledRegex]);
+
+  const perQueryRegexes = useMemo(() => {
+    const map = new Map<string, CompiledRegex>();
+    queries.forEach((query) => {
+      map.set(query.id, compileRegex(query.regex));
+    });
+    return map;
+  }, [queries]);
+
+  const queryIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    queries.forEach((query, index) => {
+      map.set(query.id, index);
+    });
+    return map;
+  }, [queries]);
 
   const loadOptions = useCallback(
     async (inputValue: string): Promise<Array<{ label: string; value: string; description?: string }>> => {
@@ -135,15 +152,15 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
               return Promise.resolve({ results: [], failedName: null });
             }
 
-            const queryName = queryConfig.name || `Query ${queries.indexOf(queryConfig) + 1}`;
+            const queryName = queryConfig.name || `Query ${(queryIndexById.get(queryConfig.id) ?? 0) + 1}`;
             const queryPromise = ds.metricFindQuery!(queryStr, {}).then((results) => {
               let activeRegex: RegExp | null = null;
               if (queryConfig.regex) {
-                  const compiled = compileRegex(queryConfig.regex);
-                  if (compiled.error) {
+                  const compiled = perQueryRegexes.get(queryConfig.id);
+                  if (compiled?.error) {
                       console.warn(`Invalid regex in query "${queryName}": ${compiled.error}`);
                   }
-                  activeRegex = compiled.regex;
+                  activeRegex = compiled?.regex ?? null;
               } else {
                   activeRegex = compiledRegexRef.current.regex;
               }
@@ -238,7 +255,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
         }
       });
     },
-    [resolvedDatasourceUid, queries, minChars, maxResults, searchMode, variableName]
+    [resolvedDatasourceUid, queries, minChars, maxResults, searchMode, variableName, perQueryRegexes, queryIndexById]
   );
 
   const handleChange = useCallback(

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { buildQuery, applyRegexTransform, compileRegex, safeMatch, MAX_REGEX_PATTERN_LENGTH, MAX_REGEX_INPUT_LENGTH, deduplicateQueries, deduplicateResults, generateQueryId, isQueryValid, getInitialVariableValue, resolveDatasourceUid } from './utils';
+import { buildQuery, applyRegexTransform, compileRegex, safeMatch, MAX_REGEX_PATTERN_LENGTH, MAX_REGEX_INPUT_LENGTH, deduplicateQueries, deduplicateResults, generateQueryId, isQueryValid, queryDedupKey, getInitialVariableValue, resolveDatasourceUid } from './utils';
 import { QueryOptions, QueryType, QueryConfig, QUERY_TYPE } from './types';
 import { MetricFindValue } from '@grafana/data';
 
@@ -228,6 +228,34 @@ describe('utils', () => {
       const elapsed = performance.now() - start;
       expect(result).toBeNull();
       expect(elapsed).toBeLessThan(100);
+    });
+  });
+
+  describe('queryDedupKey', () => {
+    it('should return the same key for configs with identical dedup fields', () => {
+      const a: QueryConfig = { id: '1', queryType: 'label_values', label: 'job', metric: 'up' };
+      const b: QueryConfig = { id: '2', queryType: 'label_values', label: 'job', metric: 'up' };
+      expect(queryDedupKey(a)).toBe(queryDedupKey(b));
+    });
+
+    it('should treat undefined and empty label as equal', () => {
+      const a: QueryConfig = { id: '1', queryType: 'label_names', metric: 'up' };
+      const b: QueryConfig = { id: '2', queryType: 'label_names', label: '', metric: 'up' };
+      expect(queryDedupKey(a)).toBe(queryDedupKey(b));
+    });
+
+    it('should differ when any dedup field differs', () => {
+      const base: QueryConfig = { id: '1', queryType: 'label_values', label: 'job', metric: 'up', queryTimeout: 5 };
+      expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, queryType: 'label_names' }));
+      expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, label: 'instance' }));
+      expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, metric: 'down' }));
+      expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, queryTimeout: 10 }));
+    });
+
+    it('should ignore fields not used for deduplication', () => {
+      const a: QueryConfig = { id: '1', queryType: 'metrics', metric: 'up', name: 'First', regex: 'a' };
+      const b: QueryConfig = { id: '2', queryType: 'metrics', metric: 'up', name: 'Second', regex: 'b' };
+      expect(queryDedupKey(a)).toBe(queryDedupKey(b));
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,10 @@ export const buildQuery = (options: QueryOptions): string => {
   }
 };
 
+export const queryDedupKey = (query: QueryConfig): string => {
+  return `${query.queryType}|${query.label ?? ''}|${query.metric}|${query.queryTimeout ?? ''}`;
+};
+
 /**
  * Remove duplicate query configurations to avoid redundant API calls.
  * Two queries are considered duplicates if they have the same (queryType, label, metric) tuple.
@@ -42,7 +46,7 @@ export const deduplicateQueries = (queries: QueryConfig[]): QueryConfig[] => {
   const result: QueryConfig[] = [];
 
   for (const query of queries) {
-    const key = `${query.queryType}|${query.label ?? ''}|${query.metric}|${query.queryTimeout ?? ''}`;
+    const key = queryDedupKey(query);
     if (!seen.has(key)) {
       seen.add(key);
       result.push(query);


### PR DESCRIPTION
## Summary
- New `queryDedupKey(q)` in `utils.ts`, shared by `deduplicateQueries` and the editor's duplicate detection (removes duplicated key logic).
- Replaced the per-query `queries.indexOf(...)` (O(n^2)) with a memoized `id -> index` map.
- Memoized per-query compiled regexes (keyed on `queries`) so they're compiled once per config change, not on every search.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:ci` (163 passed; +4 queryDedupKey tests)
- [x] `npm run build`
- [x] coverage 95.25%