### PR TITLE
feat(hook): sync selected value with external dashboard variable changes

### DIFF
--- a/src/components/DynamicSearchPanel.spec.tsx
+++ b/src/components/DynamicSearchPanel.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { DynamicSearchPanel } from './DynamicSearchPanel';
 import { PanelProps, LoadingState } from '@grafana/data';
 import { SimpleOptions, SEARCH_MODE } from '../types';
@@ -18,6 +18,11 @@ afterAll(() => {
   console.error = originalError;
 });
 
+afterEach(() => {
+  mockLocationSearch = '';
+  mockLocationSubscribers.clear();
+});
+
 const mockGetDataSourceSrv = jest.fn();
 const mockLocationService = {
   partial: jest.fn(),
@@ -25,12 +30,30 @@ const mockLocationService = {
 const mockGetVariables = jest.fn();
 const mockReplace = jest.fn();
 
+const mockLocationSubscribers = new Set<(location: { search: string }) => void>();
+let mockLocationSearch = '';
+const mockEmitLocation = (search: string) => {
+  mockLocationSearch = search;
+  mockLocationSubscribers.forEach((cb) => cb({ search: mockLocationSearch }));
+};
+
 jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => ({
     get: mockGetDataSourceSrv,
   }),
   locationService: {
     partial: (...args: unknown[]) => mockLocationService.partial(...args),
+    getLocationObservable: () => ({
+      subscribe: (cb: (location: { search: string }) => void) => {
+        mockLocationSubscribers.add(cb);
+        cb({ search: mockLocationSearch });
+        return {
+          unsubscribe: () => {
+            mockLocationSubscribers.delete(cb);
+          },
+        };
+      },
+    }),
   },
   getTemplateSrv: () => ({
     getVariables: () => mockGetVariables(),
@@ -1007,5 +1030,86 @@ describe('DynamicSearchPanel - Datasource Variable Support', () => {
         expect(screen.getByTestId('dynamic-search-panel-variable-warning')).toHaveTextContent(
             'Datasource variable "$unresolved" could not be resolved'
         );
+    });
+});
+
+describe('DynamicSearchPanel - External Variable Sync', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetVariables.mockReturnValue([{ name: 'testVar', type: 'query' }]);
+        mockReplace.mockImplementation((input: string) => input);
+    });
+
+    it('reflects an external change to the dashboard variable', async () => {
+        render(<DynamicSearchPanel {...defaultProps} />);
+
+        expect(screen.queryByTestId('dynamic-search-panel-selected-badge')).not.toBeInTheDocument();
+
+        act(() => {
+            mockEmitLocation('?var-testVar=external-value');
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toHaveTextContent('external-value');
+        });
+    });
+
+    it('clears the selection when the variable is cleared externally', async () => {
+        render(<DynamicSearchPanel {...defaultProps} />);
+
+        act(() => {
+            mockEmitLocation('?var-testVar=first');
+        });
+        await waitFor(() => {
+            expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toHaveTextContent('first');
+        });
+
+        act(() => {
+            mockEmitLocation('?var-testVar=');
+        });
+        await waitFor(() => {
+            expect(screen.queryByTestId('dynamic-search-panel-selected-badge')).not.toBeInTheDocument();
+        });
+    });
+
+    it('ignores location changes that do not include the variable param', async () => {
+        render(<DynamicSearchPanel {...defaultProps} />);
+
+        act(() => {
+            mockEmitLocation('?var-otherVar=something&from=now-1h');
+        });
+
+        expect(screen.queryByTestId('dynamic-search-panel-selected-badge')).not.toBeInTheDocument();
+    });
+
+    it('does not re-apply the value it just wrote via selection', async () => {
+        const mockMetricFindQuery = jest.fn().mockResolvedValue([
+            { text: 'node-01', value: 'node-01' },
+        ]);
+        mockGetDataSourceSrv.mockReturnValue({
+            metricFindQuery: mockMetricFindQuery,
+        });
+
+        render(<DynamicSearchPanel {...defaultProps} />);
+        const input = screen.getByTestId('combobox-input');
+        fireEvent.change(input, { target: { value: 'node' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('option-node-01')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('option-node-01'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toHaveTextContent('node-01');
+        });
+
+        mockLocationService.partial.mockClear();
+        act(() => {
+            mockEmitLocation('?var-testVar=node-01');
+        });
+
+        expect(mockLocationService.partial).not.toHaveBeenCalled();
+        expect(screen.getByTestId('dynamic-search-panel-selected-badge')).toHaveTextContent('node-01');
     });
 });

--- a/src/hooks/useDynamicSearch.spec.ts
+++ b/src/hooks/useDynamicSearch.spec.ts
@@ -3,10 +3,28 @@ import { useDynamicSearch } from './useDynamicSearch';
 import { getDataSourceSrv, locationService } from '@grafana/runtime';
 import { SEARCH_MODE, QUERY_TYPE, SimpleOptions } from '../types';
 
+const mockLocationSubscribers = new Set<(location: { search: string }) => void>();
+let mockLocationSearch = '';
+const mockEmitLocation = (search: string) => {
+  mockLocationSearch = search;
+  mockLocationSubscribers.forEach((cb) => cb({ search: mockLocationSearch }));
+};
+
 jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: jest.fn(),
   locationService: {
     partial: jest.fn(),
+    getLocationObservable: () => ({
+      subscribe: (cb: (location: { search: string }) => void) => {
+        mockLocationSubscribers.add(cb);
+        cb({ search: mockLocationSearch });
+        return {
+          unsubscribe: () => {
+            mockLocationSubscribers.delete(cb);
+          },
+        };
+      },
+    }),
   },
 }));
 
@@ -41,6 +59,8 @@ describe('useDynamicSearch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDsInstance.metricFindQuery.mockResolvedValue([]);
+    mockLocationSearch = '';
+    mockLocationSubscribers.clear();
   });
 
   it('should initialize with value from URL/store', () => {
@@ -139,5 +159,64 @@ describe('useDynamicSearch', () => {
 
     expect(result.current.selectedValue).toBeNull();
     expect(locationService.partial).toHaveBeenCalledWith({ 'var-testVar': '' }, true);
+  });
+
+  it('should update selectedValue when the dashboard variable changes externally', () => {
+    const { result } = renderHook(() => useDynamicSearch({
+        options: defaultOptions,
+        resolvedDatasourceUid: 'ds-1'
+    }));
+
+    expect(result.current.selectedValue).toBeNull();
+
+    act(() => {
+        mockEmitLocation('?var-testVar=external');
+    });
+
+    expect(result.current.selectedValue).toEqual({ label: 'external', value: 'external' });
+  });
+
+  it('should clear selectedValue when the variable is emptied externally', () => {
+    const { result } = renderHook(() => useDynamicSearch({
+        options: defaultOptions,
+        resolvedDatasourceUid: 'ds-1'
+    }));
+
+    act(() => {
+        mockEmitLocation('?var-testVar=external');
+    });
+    expect(result.current.selectedValue?.value).toBe('external');
+
+    act(() => {
+        mockEmitLocation('?var-testVar=');
+    });
+    expect(result.current.selectedValue).toBeNull();
+  });
+
+  it('should ignore location changes without the variable param', () => {
+    const { result } = renderHook(() => useDynamicSearch({
+        options: defaultOptions,
+        resolvedDatasourceUid: 'ds-1'
+    }));
+
+    act(() => {
+        mockEmitLocation('?var-other=x&from=now-6h');
+    });
+
+    expect(result.current.selectedValue).toBeNull();
+  });
+
+  it('should not write back to the URL when applying an external change', () => {
+    const { result } = renderHook(() => useDynamicSearch({
+        options: defaultOptions,
+        resolvedDatasourceUid: 'ds-1'
+    }));
+
+    act(() => {
+        mockEmitLocation('?var-testVar=external');
+    });
+
+    expect(result.current.selectedValue?.value).toBe('external');
+    expect(locationService.partial).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useDynamicSearch.ts
+++ b/src/hooks/useDynamicSearch.ts
@@ -46,6 +46,27 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
   }, [selectedValue]);
 
   useEffect(() => {
+    if (!variableName) {
+      return;
+    }
+    const key = `var-${variableName}`;
+    const subscription = locationService.getLocationObservable().subscribe((location) => {
+      const params = new URLSearchParams(location.search);
+      if (!params.has(key)) {
+        return;
+      }
+      const urlValue = params.get(key) ?? '';
+      const currentValue = selectedValueRef.current?.value ?? '';
+      if (urlValue === currentValue) {
+        return;
+      }
+      lastInputValueRef.current = '';
+      setSelectedValue(urlValue === '' ? null : { label: urlValue, value: urlValue });
+    });
+    return () => subscription.unsubscribe();
+  }, [variableName]);
+
+  useEffect(() => {
     return () => {
       if (debounceTimeoutRef.current) {
         clearTimeout(debounceTimeoutRef.current);


### PR DESCRIPTION
## Summary
- Subscribe to `locationService.getLocationObservable()` so `selectedValue` reflects external dashboard variable edits, not just the mount-time initial value.
- Guard against feedback loops: ignore unrelated params and skip when the URL value already equals the current selection (compared via `selectedValueRef`), so the hook never re-writes the change it just consumed.
- Clear selection when the variable is emptied externally; unsubscribe on unmount.

## Tests
- Hook spec: controllable location-observable mock + 4 sync tests (external set, external clear, unrelated param ignored, no URL write-back).
- Panel spec: UI reflects external variable changes.
- 171 unit tests pass; `typecheck`, `lint` (0 errors), `build` green.