### PR TITLE
feat(panel): add raw query mode for any datasource

### DIFF
--- a/src/components/DataSourcePickerEditor.spec.tsx
+++ b/src/components/DataSourcePickerEditor.spec.tsx
@@ -52,8 +52,9 @@ describe('DataSourcePickerEditor', () => {
       { type: 'query', name: 'other', query: '' },
     ]);
     mockGetList.mockReturnValue([
-      { uid: 'prometheus-uid', name: 'Prometheus', isDefault: true },
-      { uid: 'prometheus-2', name: 'Prometheus 2', isDefault: false },
+      { uid: 'prometheus-uid', name: 'Prometheus', isDefault: true, type: 'prometheus' },
+      { uid: 'prometheus-2', name: 'Prometheus 2', isDefault: false, type: 'prometheus' },
+      { uid: 'influx-1', name: 'InfluxDB', isDefault: false, type: 'influxdb' },
     ]);
   });
 
@@ -69,16 +70,18 @@ describe('DataSourcePickerEditor', () => {
     expect(mockOnChange).toHaveBeenCalledWith('prometheus-2');
   });
 
-  it('shows only prometheus-type variables', () => {
+  it('shows all datasource-type variables regardless of datasource type', () => {
     render(<DataSourcePickerEditor {...defaultProps} />);
     expect(screen.getByText('$datasource')).toBeInTheDocument();
-    expect(screen.queryByText('$testdb')).not.toBeInTheDocument();
+    expect(screen.getByText('$testdb')).toBeInTheDocument();
+    expect(screen.queryByText('$other')).not.toBeInTheDocument();
   });
 
-  it('shows prometheus datasources', () => {
+  it('shows datasources of any type', () => {
     render(<DataSourcePickerEditor {...defaultProps} />);
     expect(screen.getAllByText('Prometheus').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Prometheus 2')).toBeInTheDocument();
+    expect(screen.getByText('InfluxDB')).toBeInTheDocument();
   });
 
   it('renders with empty value', () => {

--- a/src/components/DataSourcePickerEditor.tsx
+++ b/src/components/DataSourcePickerEditor.tsx
@@ -10,28 +10,22 @@ const DataSourcePickerEditorComponent: React.FC<Props> = ({ value, onChange }) =
     const result: Array<ComboboxOption<string>> = [];
 
     const dsSrv = getDataSourceSrv();
-    const promDatasources = dsSrv.getList({ type: 'prometheus' });
+    const allDatasources = dsSrv.getList();
 
-    const prometheusVariables = getTemplateSrv()
+    const datasourceVariables = getTemplateSrv()
       .getVariables()
-      .filter((v) => {
-        if (v.type !== 'datasource') {
-          return false;
-        }
-        const dsVar = v as { query?: string };
-        return dsVar.query === 'prometheus';
-      })
+      .filter((v) => v.type === 'datasource')
       .map((v) => ({
         label: `$${v.name}`,
         value: `$${v.name}`,
         description: 'Dashboard variable',
       }));
-    result.push(...prometheusVariables);
+    result.push(...datasourceVariables);
 
-    const datasources = promDatasources.map((ds) => ({
+    const datasources = allDatasources.map((ds) => ({
       label: ds.name,
       value: ds.uid ?? '',
-      description: ds.isDefault ? 'Default' : undefined,
+      description: ds.isDefault ? `Default • ${ds.type}` : ds.type,
     }));
     result.push(...datasources);
 

--- a/src/components/DynamicSearchPanel.spec.tsx
+++ b/src/components/DynamicSearchPanel.spec.tsx
@@ -240,7 +240,7 @@ describe('DynamicSearchPanel', () => {
     it('flags queries that cannot build a query as invalid configuration', async () => {
         render(<DynamicSearchPanel {...defaultProps} options={{ ...defaultOptions, queries: [{ id: 'q-1', queryType: 'invalid' as any, metric: 'up' }] }} />);
 
-        expect(await screen.findByText('At least one valid query (check metric and label fields)')).toBeInTheDocument();
+        expect(await screen.findByText('At least one valid query (check metric, label, or raw query fields)')).toBeInTheDocument();
         expect(screen.queryByTestId('combobox-input')).not.toBeInTheDocument();
     });
 

--- a/src/components/DynamicSearchPanel.tsx
+++ b/src/components/DynamicSearchPanel.tsx
@@ -201,7 +201,7 @@ const DynamicSearchPanelComponent = ({ options, width, height }: Props) => {
     } else {
       const hasValidQuery = queries.some(isQueryValid);
       if (!hasValidQuery) {
-        missing.push('At least one valid query (check metric and label fields)');
+        missing.push('At least one valid query (check metric, label, or raw query fields)');
       }
     }
 

--- a/src/components/QueriesEditor.spec.tsx
+++ b/src/components/QueriesEditor.spec.tsx
@@ -31,6 +31,17 @@ jest.mock('@grafana/ui', () => ({
       type={type}
     />
   ),
+  TextArea: ({ value, onChange, placeholder }: {
+    value: string;
+    onChange: (e: { currentTarget: { value: string } }) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      value={value}
+      onChange={(e) => onChange({ currentTarget: { value: e.target.value } })}
+      placeholder={placeholder}
+    />
+  ),
   useStyles2: () => ({
     container: '',
     queryCard: '',
@@ -179,5 +190,28 @@ describe('QueriesEditor', () => {
     const queries = [makeQuery({ metric: 'up', label: 'job', queryType: QUERY_TYPE.LABEL_VALUES })];
     render(<QueriesEditor {...defaultProps} value={queries} />);
     expect(screen.getByText('label_values(up, job)')).toBeInTheDocument();
+  });
+
+  it('should show a raw query textarea instead of metric for raw type', () => {
+    const queries = [makeQuery({ queryType: QUERY_TYPE.RAW, metric: '', label: '', rawQuery: 'label_values(up, job)' })];
+    render(<QueriesEditor {...defaultProps} value={queries} />);
+    expect(screen.getByPlaceholderText('Datasource-specific query, e.g., label_values(up, job)')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('e.g., up, http_requests_total')).not.toBeInTheDocument();
+  });
+
+  it('should update rawQuery when the raw textarea changes', () => {
+    const queries = [makeQuery({ queryType: QUERY_TYPE.RAW, metric: '', label: '', rawQuery: '' })];
+    render(<QueriesEditor {...defaultProps} value={queries} />);
+    const textarea = screen.getByPlaceholderText('Datasource-specific query, e.g., label_values(up, job)');
+    fireEvent.change(textarea, { target: { value: 'metrics(.*)' } });
+    expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onChange.mock.calls[0][0][0].rawQuery).toBe('metrics(.*)');
+  });
+
+  it('should render the raw query verbatim in the preview', () => {
+    const queries = [makeQuery({ queryType: QUERY_TYPE.RAW, metric: '', label: '', rawQuery: 'SHOW TAG VALUES' })];
+    render(<QueriesEditor {...defaultProps} value={queries} />);
+    const matches = screen.getAllByText('SHOW TAG VALUES');
+    expect(matches.some((el) => el.tagName === 'DIV')).toBe(true);
   });
 });

--- a/src/components/QueriesEditor.tsx
+++ b/src/components/QueriesEditor.tsx
@@ -3,6 +3,7 @@ import { StandardEditorProps, GrafanaTheme2 } from '@grafana/data';
 import {
   IconButton,
   Input,
+  TextArea,
   useStyles2,
   Icon,
   Combobox,
@@ -17,6 +18,7 @@ const queryTypeOptions = [
   { value: QUERY_TYPE.LABEL_VALUES as QueryType, label: 'Label values' },
   { value: QUERY_TYPE.LABEL_NAMES as QueryType, label: 'Label names' },
   { value: QUERY_TYPE.METRICS as QueryType, label: 'Metrics' },
+  { value: QUERY_TYPE.RAW as QueryType, label: 'Raw' },
 ];
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -173,7 +175,9 @@ const QueriesEditorComponent: React.FC<Props> = ({ value, onChange }) => {
           queryType: query.queryType,
           label: query.label,
           metric: query.metric || '',
+          rawQuery: query.rawQuery,
         });
+        const isRaw = query.queryType === QUERY_TYPE.RAW;
 
         return (
           <div
@@ -223,22 +227,36 @@ const QueriesEditorComponent: React.FC<Props> = ({ value, onChange }) => {
               </div>
             )}
 
-            <div className={styles.fieldRow}>
-              <label className={styles.fieldLabel}>
-                {query.queryType === QUERY_TYPE.LABEL_VALUES ? 'Metric' : 'Metric (optional)'}
-              </label>
-              <Input
-                value={query.metric}
-                onChange={(e) =>
-                  updateQuery(index, { metric: e.currentTarget.value })
-                }
-                placeholder={
-                  query.queryType === QUERY_TYPE.LABEL_VALUES
-                    ? 'e.g., up, http_requests_total'
-                    : 'Leave empty to list all'
-                }
-              />
-            </div>
+            {isRaw ? (
+              <div className={styles.fieldRow}>
+                <label className={styles.fieldLabel}>Raw query *</label>
+                <TextArea
+                  value={query.rawQuery ?? ''}
+                  onChange={(e) =>
+                    updateQuery(index, { rawQuery: e.currentTarget.value })
+                  }
+                  rows={3}
+                  placeholder="Datasource-specific query, e.g., label_values(up, job)"
+                />
+              </div>
+            ) : (
+              <div className={styles.fieldRow}>
+                <label className={styles.fieldLabel}>
+                  {query.queryType === QUERY_TYPE.LABEL_VALUES ? 'Metric' : 'Metric (optional)'}
+                </label>
+                <Input
+                  value={query.metric}
+                  onChange={(e) =>
+                    updateQuery(index, { metric: e.currentTarget.value })
+                  }
+                  placeholder={
+                    query.queryType === QUERY_TYPE.LABEL_VALUES
+                      ? 'e.g., up, http_requests_total'
+                      : 'Leave empty to list all'
+                  }
+                />
+              </div>
+            )}
 
             <div className={styles.fieldRow}>
               <label className={styles.fieldLabel}>Regex</label>

--- a/src/hooks/useDynamicSearch.ts
+++ b/src/hooks/useDynamicSearch.ts
@@ -147,7 +147,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
           }
 
           const queryPromises = uniqueQueries.map((queryConfig) => {
-            const queryStr = buildQuery({ queryType: queryConfig.queryType, label: queryConfig.label, metric: queryConfig.metric });
+            const queryStr = buildQuery({ queryType: queryConfig.queryType, label: queryConfig.label, metric: queryConfig.metric, rawQuery: queryConfig.rawQuery });
             if (!queryStr) {
               return Promise.resolve({ results: [], failedName: null });
             }

--- a/src/module.ts
+++ b/src/module.ts
@@ -55,7 +55,7 @@ export const plugin = new PanelPlugin<SimpleOptions>(DynamicSearchPanel)
         id: 'datasourceUid',
         path: 'datasourceUid',
         name: 'Datasource *',
-        description: 'Select the Prometheus datasource to query',
+        description: 'Select the datasource to query (Prometheus-style types support the built-in query builder; use Raw for any datasource)',
         editor: DataSourcePickerEditor,
         category: ['Data Source'],
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export const QUERY_TYPE = {
     LABEL_VALUES: 'label_values',
     LABEL_NAMES: 'label_names',
     METRICS: 'metrics',
+    RAW: 'raw',
 } as const;
 
 export type QueryType = (typeof QUERY_TYPE)[keyof typeof QUERY_TYPE];
@@ -21,6 +22,8 @@ export interface QueryConfig {
     queryType: QueryType;
     label?: string;
     metric: string;
+    /** Raw datasource query string, used verbatim when queryType is RAW */
+    rawQuery?: string;
     /** Regex pattern to transform results using capture groups */
     regex?: string;
     /** Maximum time in seconds to wait for this specific query (0 for no timeout) */
@@ -61,4 +64,5 @@ export interface QueryOptions {
     queryType: QueryType;
     label?: string;
     metric: string;
+    rawQuery?: string;
 }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -89,6 +89,35 @@ describe('utils', () => {
         };
         expect(buildQuery(options)).toBe('');
     });
+
+    it('should return the raw query verbatim for raw type', () => {
+      const options: QueryOptions = {
+        ...defaultOptions,
+        queryType: 'raw',
+        metric: '',
+        rawQuery: 'SHOW TAG VALUES FROM "cpu" WITH KEY = "host"',
+      };
+      expect(buildQuery(options)).toBe('SHOW TAG VALUES FROM "cpu" WITH KEY = "host"');
+    });
+
+    it('should return empty string for raw type with blank query', () => {
+      const options: QueryOptions = {
+        ...defaultOptions,
+        queryType: 'raw',
+        metric: '',
+        rawQuery: '   ',
+      };
+      expect(buildQuery(options)).toBe('');
+    });
+
+    it('should return empty string for raw type with no query', () => {
+      const options: QueryOptions = {
+        ...defaultOptions,
+        queryType: 'raw',
+        metric: '',
+      };
+      expect(buildQuery(options)).toBe('');
+    });
   });
 
   describe('applyRegexTransform', () => {
@@ -250,6 +279,7 @@ describe('utils', () => {
       expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, label: 'instance' }));
       expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, metric: 'down' }));
       expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, queryTimeout: 10 }));
+      expect(queryDedupKey(base)).not.toBe(queryDedupKey({ ...base, rawQuery: 'up' }));
     });
 
     it('should ignore fields not used for deduplication', () => {
@@ -400,6 +430,14 @@ describe('utils', () => {
 
     it('should return false for label_values without label', () => {
       expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.LABEL_VALUES, metric: 'up', label: '', name: '' })).toBe(false);
+    });
+
+    it('should return true for raw query with a non-empty rawQuery', () => {
+      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.RAW, metric: '', rawQuery: 'label_values(up, job)', name: '' })).toBe(true);
+    });
+
+    it('should return false for raw query with a blank rawQuery', () => {
+      expect(isQueryValid({ id: '1', queryType: QUERY_TYPE.RAW, metric: '', rawQuery: '  ', name: '' })).toBe(false);
     });
 
     it('should return false for an unknown query type', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export const generateQueryId = (): string => {
 };
 
 export const buildQuery = (options: QueryOptions): string => {
-  const { queryType, label, metric } = options;
+  const { queryType, label, metric, rawQuery } = options;
 
   switch (queryType) {
     case QUERY_TYPE.LABEL_VALUES:
@@ -28,13 +28,15 @@ export const buildQuery = (options: QueryOptions): string => {
       return metric ? `label_names(${metric})` : 'label_names()';
     case QUERY_TYPE.METRICS:
       return metric ? `metrics(${metric})` : 'metrics(.*)';
+    case QUERY_TYPE.RAW:
+      return rawQuery?.trim() ? rawQuery : '';
     default:
       return '';
   }
 };
 
 export const queryDedupKey = (query: QueryConfig): string => {
-  return `${query.queryType}|${query.label ?? ''}|${query.metric}|${query.queryTimeout ?? ''}`;
+  return `${query.queryType}|${query.label ?? ''}|${query.metric}|${query.rawQuery ?? ''}|${query.queryTimeout ?? ''}`;
 };
 
 /**
@@ -132,7 +134,7 @@ export const applyRegexTransform = (
 };
 
 export const isQueryValid = (q: QueryConfig): boolean => {
-  return buildQuery({ queryType: q.queryType, label: q.label, metric: q.metric }) !== '';
+  return buildQuery({ queryType: q.queryType, label: q.label, metric: q.metric, rawQuery: q.rawQuery }) !== '';
 };
 
 export const getInitialVariableValue = (variableName: string | undefined): SelectableValue<string> | null => {

--- a/tests/panel.spec.ts
+++ b/tests/panel.spec.ts
@@ -207,6 +207,31 @@ test.describe('Dynamic Search Panel', () => {
     await expect(labelInput).toBeVisible();
   });
 
+  test('should show a raw query textarea and hide metric when query type is raw', async ({
+    dashboardPage,
+    readProvisionedDashboard,
+    page,
+  }) => {
+    const dashboard = await readProvisionedDashboard({ fileName: 'dashboard.json' });
+    await dashboardPage.goto({ uid: dashboard.uid });
+    const panelEditPage = await dashboardPage.addPanel();
+    await panelEditPage.setVisualization('Dynamic Search');
+
+    await page.getByTestId('add-query-button').click();
+    const queryCard = page.getByTestId('query-card-0');
+    const metricInput = queryCard.getByPlaceholder('e.g., up, http_requests_total');
+
+    await expect(metricInput).toBeVisible();
+
+    await queryCard.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Raw' }).click();
+
+    await expect(metricInput).not.toBeVisible();
+    await expect(
+      queryCard.getByPlaceholder('Datasource-specific query, e.g., label_values(up, job)')
+    ).toBeVisible();
+  });
+
   test('should display custom placeholder text', async ({
     dashboardPage,
     readProvisionedDashboard,


### PR DESCRIPTION
## Summary
- Add `QUERY_TYPE.RAW` + a `rawQuery` field on `QueryConfig`; `buildQuery` returns the raw string verbatim (empty when blank).
- `isQueryValid` and `queryDedupKey` account for `rawQuery`; the hook passes `rawQuery` through to `metricFindQuery`.
- Datasource picker is now datasource-agnostic (drops the `type: 'prometheus'` filter; lists all datasources and all datasource variables, with the type shown in the description).
- `QueriesEditor` shows a raw-query textarea for `RAW` and hides the metric field; preview renders the raw string verbatim.

## Notes
- No `SimpleOptions` field added (the new field lives on `QueryConfig`), so no migration handler change is required; `rawQuery` is optional and existing queries are unaffected.

## Tests
- Unit: `buildQuery`/`isQueryValid`/`queryDedupKey` RAW cases; `QueriesEditor` raw textarea render/update/preview; datasource picker lists any type + all datasource variables. 171 unit tests pass.
- E2E: new test asserts the raw textarea appears and the metric field hides when the query type is Raw (runs in CI).
- `typecheck`, `lint` (0 errors), `build` green.