### PR TITLE
feat(hook): add TTL result cache to skip repeat datasource calls

### DIFF
--- a/src/hooks/useDynamicSearch.spec.ts
+++ b/src/hooks/useDynamicSearch.spec.ts
@@ -140,4 +140,92 @@ describe('useDynamicSearch', () => {
     expect(result.current.selectedValue).toBeNull();
     expect(locationService.partial).toHaveBeenCalledWith({ 'var-testVar': '' }, true);
   });
+
+  describe('result caching', () => {
+    const cachedOptions: SimpleOptions = { ...defaultOptions, cacheTtl: 60 };
+
+    it('should not call the datasource again for a cache hit within the TTL', async () => {
+      mockDsInstance.metricFindQuery.mockResolvedValue([{ text: 'abc-result', value: 'v1' }]);
+      const { result } = renderHook(() => useDynamicSearch({ options: cachedOptions, resolvedDatasourceUid: 'ds-1' }));
+
+      let first: Array<{ label: string; value: string }> = [];
+      await act(async () => {
+        first = await result.current.loadOptions('abc');
+      });
+      expect(mockDsInstance.metricFindQuery).toHaveBeenCalledTimes(1);
+
+      let second: Array<{ label: string; value: string }> = [];
+      await act(async () => {
+        second = await result.current.loadOptions('abc');
+      });
+
+      expect(mockDsInstance.metricFindQuery).toHaveBeenCalledTimes(1);
+      expect(second).toEqual(first);
+    });
+
+    it('should call the datasource for each distinct input', async () => {
+      mockDsInstance.metricFindQuery.mockResolvedValue([{ text: 'abc-result', value: 'v1' }]);
+      const { result } = renderHook(() => useDynamicSearch({ options: cachedOptions, resolvedDatasourceUid: 'ds-1' }));
+
+      await act(async () => {
+        await result.current.loadOptions('abc');
+      });
+      await act(async () => {
+        await result.current.loadOptions('abcd');
+      });
+
+      expect(mockDsInstance.metricFindQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache when caching is disabled', async () => {
+      mockDsInstance.metricFindQuery.mockResolvedValue([{ text: 'abc-result', value: 'v1' }]);
+      const { result } = renderHook(() => useDynamicSearch({ options: defaultOptions, resolvedDatasourceUid: 'ds-1' }));
+
+      await act(async () => {
+        await result.current.loadOptions('abc');
+      });
+      await act(async () => {
+        await result.current.loadOptions('abc');
+      });
+
+      expect(mockDsInstance.metricFindQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache results when a query fails', async () => {
+      mockDsInstance.metricFindQuery.mockRejectedValue(new Error('API Error'));
+      const { result } = renderHook(() => useDynamicSearch({ options: cachedOptions, resolvedDatasourceUid: 'ds-1' }));
+
+      await act(async () => {
+        await result.current.loadOptions('abc');
+      });
+      await act(async () => {
+        await result.current.loadOptions('abc');
+      });
+
+      expect(mockDsInstance.metricFindQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-query once the cached entry expires', async () => {
+      mockDsInstance.metricFindQuery.mockResolvedValue([{ text: 'abc-result', value: 'v1' }]);
+      const shortTtl: SimpleOptions = { ...defaultOptions, cacheTtl: 1 };
+      const nowSpy = jest.spyOn(Date, 'now');
+      nowSpy.mockReturnValue(1_000_000);
+
+      const { result } = renderHook(() => useDynamicSearch({ options: shortTtl, resolvedDatasourceUid: 'ds-1' }));
+
+      await act(async () => {
+        await result.current.loadOptions('abc');
+      });
+      expect(mockDsInstance.metricFindQuery).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockReturnValue(1_000_000 + 2_000);
+
+      await act(async () => {
+        await result.current.loadOptions('abc');
+      });
+      expect(mockDsInstance.metricFindQuery).toHaveBeenCalledTimes(2);
+
+      nowSpy.mockRestore();
+    });
+  });
 });

--- a/src/hooks/useDynamicSearch.ts
+++ b/src/hooks/useDynamicSearch.ts
@@ -11,6 +11,7 @@ import {
   deduplicateResults,
   isQueryValid,
   getInitialVariableValue,
+  queryDedupKey,
   MIN_SEARCH_LENGTH,
   DEBOUNCE_DELAY,
 } from '../utils';
@@ -20,12 +21,22 @@ interface UseDynamicSearchArgs {
   resolvedDatasourceUid: string | undefined;
 }
 
+type LoadOptionsResult = Array<{ label: string; value: string; description?: string }>;
+
+interface CacheEntry {
+  expires: number;
+  value: LoadOptionsResult;
+}
+
+const MAX_CACHE_ENTRIES = 100;
+
 export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicSearchArgs) => {
   const { variableName, regex } = options;
   const queries: QueryConfig[] = useMemo(() => options.queries ?? [], [options.queries]);
   const minChars = options.minChars ?? MIN_SEARCH_LENGTH;
   const maxResults = options.maxResults ?? 0;
   const searchMode = options.searchMode ?? SEARCH_MODE.CONTAINS;
+  const cacheTtl = options.cacheTtl ?? 0;
 
   const [selectedValue, setSelectedValue] = useState<SelectableValue<string> | null>(() =>
     getInitialVariableValue(variableName)
@@ -81,6 +92,17 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
     return map;
   }, [queries]);
 
+  const queriesSignature = useMemo(
+    () => queries.map((q) => `${queryDedupKey(q)}~${q.regex ?? ''}`).join('||'),
+    [queries]
+  );
+
+  const cacheRef = useRef<Map<string, CacheEntry>>(new Map());
+
+  useEffect(() => {
+    cacheRef.current.clear();
+  }, [resolvedDatasourceUid, queriesSignature, searchMode, maxResults, regex]);
+
   const loadOptions = useCallback(
     async (inputValue: string): Promise<Array<{ label: string; value: string; description?: string }>> => {
       if (debounceTimeoutRef.current) {
@@ -123,6 +145,17 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
       }).then(async (shouldProceed) => {
         if (!shouldProceed || currentRequestId !== requestIdRef.current) {
           return [];
+        }
+
+        if (cacheTtl > 0) {
+          const cached = cacheRef.current.get(inputValue);
+          if (cached && cached.expires > Date.now()) {
+            setFailedQueries([]);
+            setHasSearched(true);
+            setLastResultCount(cached.value.length);
+            setIsLoading(false);
+            return cached.value;
+          }
         }
 
         setIsLoading(true);
@@ -198,6 +231,19 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
           const failedNames = allSettled.map(r => r.failedName).filter((name): name is string => name !== null);
           setFailedQueries(failedNames);
 
+          const cacheResult = (value: LoadOptionsResult) => {
+            if (cacheTtl > 0 && failedNames.length === 0) {
+              if (cacheRef.current.size >= MAX_CACHE_ENTRIES) {
+                const oldestKey = cacheRef.current.keys().next().value;
+                if (oldestKey !== undefined) {
+                  cacheRef.current.delete(oldestKey);
+                }
+              }
+              cacheRef.current.set(inputValue, { expires: Date.now() + cacheTtl * 1000, value });
+            }
+            return value;
+          };
+
           const mergedResults = deduplicateResults(allSettled.flatMap(r => r.results));
 
           let filteredResults = mergedResults;
@@ -222,7 +268,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
 
           if (filteredResults.length === 0) {
             setLastResultCount(0);
-            return [];
+            return cacheResult([]);
           }
 
           let transformed = filteredResults;
@@ -233,7 +279,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
 
           setLastResultCount(transformed.length);
 
-          return transformed
+          const mapped = transformed
             .map((r) => {
               const val = r.value !== undefined ? String(r.value) : r.text;
               return {
@@ -243,6 +289,8 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
               };
             })
             .filter((r) => typeof r.value === 'string' && r.value !== '');
+
+          return cacheResult(mapped);
         } catch (err) {
           if (currentRequestId !== requestIdRef.current) {
             return [];
@@ -255,7 +303,7 @@ export const useDynamicSearch = ({ options, resolvedDatasourceUid }: UseDynamicS
         }
       });
     },
-    [resolvedDatasourceUid, queries, minChars, maxResults, searchMode, variableName, perQueryRegexes, queryIndexById]
+    [resolvedDatasourceUid, queries, minChars, maxResults, searchMode, variableName, perQueryRegexes, queryIndexById, cacheTtl]
   );
 
   const handleChange = useCallback(

--- a/src/module.ts
+++ b/src/module.ts
@@ -107,6 +107,17 @@ export const plugin = new PanelPlugin<SimpleOptions>(DynamicSearchPanel)
         },
         category: ['Display'],
       })
+      .addNumberInput({
+        path: 'cacheTtl',
+        name: 'Cache TTL (s)',
+        description: 'Cache query results per search input for this many seconds (0 disables caching)',
+        defaultValue: 0,
+        settings: {
+          min: 0,
+          integer: true,
+        },
+        category: ['Display'],
+      })
       .addSelect({
         path: 'searchMode',
         name: 'Search Mode',

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface SimpleOptions {
     maxResults?: number;
     placeholder?: string;
     searchMode?: SearchMode;
+    /** Seconds to cache query results per input; 0 disables caching */
+    cacheTtl?: number;
     /** @deprecated Use queries[].queryTimeout instead. Kept for migration. */
     queryTimeout?: number;
 }


### PR DESCRIPTION
## Summary
- Add a `cacheTtl` option (seconds; `0` disables). When set, `loadOptions` caches the final result per search input in an in-hook `Map` and serves hits within the TTL without calling the datasource.
- Cache is invalidated whenever the resolved datasource, query set/regex signature, search mode, or max results change.
- Failed queries are never cached; the map is size-bounded (100 entries, oldest evicted) to prevent unbounded growth.

## Tests
- Hook spec: cache hit within TTL (single datasource call), distinct inputs re-query, caching disabled by default, failures not cached, re-query after TTL expiry (via mocked `Date.now`). 168 unit tests pass.
- `typecheck`, `lint` (0 errors), `build` green.